### PR TITLE
chore: introduce Hypersistence Utils

### DIFF
--- a/.config/detekt/detekt.yaml
+++ b/.config/detekt/detekt.yaml
@@ -12,6 +12,8 @@ comments:
   UndocumentedPublicClass:
     active: true
     severity: warning
+    ignoreAnnotated:
+      - org.springframework.stereotype.Repository  # Trivial semantic
   UndocumentedPublicFunction:
     active: true
     severity: warning

--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -2,12 +2,14 @@
   <dictionary name="project">
     <words>
       <w>ElaastiX</w>
+      <w>Hypersistence</w>
       <w>Traefik</w>
       <w>affero</w>
       <w>agpl</w>
       <w>detekt</w>
       <w>elaastic</w>
       <w>elaastix</w>
+      <w>hypersistence's</w>
       <w>ktlint</w>
       <w>tmpfs</w>
       <w>traefik</w>

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
 dependencies {
     implementation(libs.spring.boot.jpa)
     implementation(libs.spring.boot.validation)
+    implementation(libs.hypersistence.utils)
 
     testImplementation(libs.spring.boot.jpa.test)
     testImplementation(libs.spring.boot.validation.test)

--- a/commons/src/main/kotlin/org/elaastix/commons/jpa/ElaastixRepository.kt
+++ b/commons/src/main/kotlin/org/elaastix/commons/jpa/ElaastixRepository.kt
@@ -19,16 +19,20 @@
 
 package org.elaastix.commons.jpa
 
-import org.springframework.data.jpa.repository.JpaRepository
+import io.hypersistence.utils.spring.repository.BaseJpaRepository
+import org.springframework.data.repository.NoRepositoryBean
 import kotlin.uuid.Uuid
 
 /**
- * Specialised Repository type for use in all Elaastix projects. Pre-defines the correct type for identifiers to
- * reduce repetitions.
- *
- * Repositories will expect Kotlin's [Uuid] instead of Java's [java.util.UUID] for better integration with the
- * rest of the codebase. The [UuidConverter] will transparently convert it to something JPA can work with.
+ * Specialised Repository type for use in all Elaastix projects.
+ * Wrapper around Hypersistence Utils's [BaseJpaRepository].
  *
  * @param T Type of entities managed by the repository. Must be a subclass of [AbstractEntity].
  */
-interface ElaastixRepository<T : AbstractEntity> : JpaRepository<T, Uuid>
+@NoRepositoryBean
+interface ElaastixRepository<T : AbstractEntity> : BaseJpaRepository<T, Uuid> {
+    /**
+     * Helper to use Kotlin nullability instead of Java's `Optional`, which is more idiomatic.
+     */
+    fun findByIdOrNull(id: Uuid): T? = findById(id).orElse(null)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,24 @@
 [versions]
 jdk = "25"
-kotlin = "2.3.0"
+kotlin = "2.3.10"
 # ----
 detekt = "2.0.0-alpha.2"
-flyway = "11.20.0"
-hibernate = "7.1.8.Final"
+flyway = "12.0.1"
+hibernate = "7.2.4.Final" # CAREFUL!! Hypersistence Utils module target MUST be adjusted accordingly!!
 ideax = "1.3"
-jdbc-postgresql = "42.7.8"
-junit = "6.0.1"
+jdbc-postgresql = "42.7.9"
+junit = "6.0.3"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.10.0"
-mockk = "1.14.7"
-spring-boot = "4.0.1"
+mockk = "1.14.9"
+spring-boot = "4.0.2"
+hypersistence-utils = "3.15.2"
 
 [libraries]
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 detekt-ktlint = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }
 flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
+hypersistence-utils = { module = "io.hypersistence:hypersistence-utils-hibernate-71", version.ref = "hypersistence-utils" }
 jdbc-postgresql = { module = "org.postgresql:postgresql", version.ref = "jdbc-postgresql" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(libs.spring.boot.webmvc)
     implementation(libs.spring.boot.kotlinx.serialization.json)
     implementation(libs.flyway.postgresql)
+    implementation(libs.hypersistence.utils)
     runtimeOnly(libs.jdbc.postgresql)
 
     testImplementation(libs.spring.boot.actuator.test)

--- a/server/src/main/kotlin/org/elaastix/server/ElaastixServerApplication.kt
+++ b/server/src/main/kotlin/org/elaastix/server/ElaastixServerApplication.kt
@@ -19,12 +19,17 @@
 
 package org.elaastix.server
 
+import io.hypersistence.utils.spring.repository.BaseJpaRepositoryImpl
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+// TODO: Find a more elegant solution to automatically configure it within Elaastix Commons
+// Not fond of having this here, but let's avoid another time sink for now.
+@EnableJpaRepositories(repositoryBaseClass = BaseJpaRepositoryImpl::class)
 @Suppress("UndocumentedPublicClass")
 class ElaastixServerApplication
 

--- a/server/src/main/kotlin/org/elaastix/server/authn/AuthenticationHolder.kt
+++ b/server/src/main/kotlin/org/elaastix/server/authn/AuthenticationHolder.kt
@@ -25,13 +25,31 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpClientErrorException
 
+/**
+ * Facade exposing the authentication status for the current request context.
+ *
+ * For correctness, [authenticatedUser] is specified as nullable, as there is no guarantee authentication succeeded.
+ * Only after checking for whether the user is non-null can we safely assert that the user is indeed authenticated.
+ *
+ * A convenience helper [`User?.required`][required] is provided to get a non-nullable [User] without having to deal
+ * with null checking everytime.
+ */
 @Component
 class AuthenticationHolder {
+    /**
+     * Whether the current context holds a valid authentication.
+     */
     val isAuthenticated: Boolean
         get() = SecurityContextHolder.getContext().authentication?.isAuthenticated == true
 
+    /**
+     * Authenticated user for the current context. `null` if unauthenticated.
+     */
     val authenticatedUser: User?
         get() = SecurityContextHolder.getContext().authentication?.principal as? User
 }
 
+/**
+ * Convenience helper for getting a non-null [User] reference, aborting the HTTP request with status code 401 otherwise.
+ */
 fun User?.required(): User = this ?: throw HttpClientErrorException(HttpStatus.UNAUTHORIZED)

--- a/server/src/main/kotlin/org/elaastix/server/bootstrap/DatabaseSeeder.kt
+++ b/server/src/main/kotlin/org/elaastix/server/bootstrap/DatabaseSeeder.kt
@@ -24,25 +24,39 @@ import org.elaastix.server.users.entities.User
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Profile
+import org.springframework.data.domain.Example
+import org.springframework.data.domain.ExampleMatcher
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
+/**
+ * Component responsible for populating, in development, the database with initial data.
+ * Does not run during unit and integration tests. Individual tests are responsible for setting up their data; relying
+ * on data created outside the scope of the tests is a bad practice.
+ */
 @Component
-@Profile("develop")
-class DatabaseSeeder(val userRepository: UserRepository) : ApplicationRunner {
+@Profile("develop & !testing")
+class DatabaseSeeder(private val userRepository: UserRepository) : ApplicationRunner {
     override fun run(args: ApplicationArguments) {
         doInitUsers()
     }
 
     private fun doInitUsers() {
         if (userRepository.count() == 0L) {
-            userRepository.save(User())
-            userRepository.save(User())
-            userRepository.save(User())
+            userRepository.persist(User())
+            userRepository.persist(User())
+            userRepository.persist(User())
         }
 
-        @Suppress("MagicNumber")
-        userRepository.findAll(Pageable.ofSize(3))
+        // Gross workaround the lack of findAll.
+        userRepository.findAll(
+            Example.of(
+                User(),
+                ExampleMatcher.matchingAny(),
+            ),
+            @Suppress("MagicNumber")
+            Pageable.ofSize(3),
+        )
             .forEachIndexed { idx, user -> println("Test user ${idx + 1}: ${user.id}") }
     }
 }

--- a/server/src/main/kotlin/org/elaastix/server/config/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/org/elaastix/server/config/WebSecurityConfig.kt
@@ -34,7 +34,10 @@ import org.springframework.security.web.util.matcher.AnyRequestMatcher
 
 @Configuration
 @EnableWebSecurity
-class WebSecurityConfig(val authProvider: AuthnTmpProvider, val authConfig: AuthenticationConfiguration) {
+class WebSecurityConfig(
+    private val authProvider: AuthnTmpProvider,
+    private val authConfig: AuthenticationConfiguration,
+) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http.authenticationProvider(authProvider)


### PR DESCRIPTION
Provides lots of performance-oriented and semantic improvements over the unfortunate defaults of Spring Data. Also fills the gaps where JPA is lacking, notably around json-native types.

Relates to #169 