### PR TITLE
fix: better type conversion, refactor timestamp update logic

### DIFF
--- a/.idea/jpb-settings.xml
+++ b/.idea/jpb-settings.xml
@@ -17,6 +17,14 @@
             <java-class>org.elaastix.mm.content.RichContent</java-class>
             <sql-type>jsonb</sql-type>
           </mapping-type>
+          <mapping-type sql-type-parameter="Nothing">
+            <java-class>kotlin.UInt</java-class>
+            <sql-type>integer</sql-type>
+          </mapping-type>
+          <mapping-type sql-type-parameter="Nothing">
+            <java-class>kotlin.ULong</java-class>
+            <sql-type>bigint</sql-type>
+          </mapping-type>
         </mapping-types>
       </database-info>
     </database-infos>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The following commands automatically become available:
 - `garage`
 
 ### Editor
+> [!CAUTION]
+> IntelliJ IDEA currently has some major regressions with WSL support as of 2026.1. See []
+> While the usual advice is to use the latest versions, **do not upgrade to the 2026 series yet**.
+
 The project is configured for IntelliJ IDEA Ultimate. In other editions of IntelliJ IDEA, Spring support is limited
 and there is no support for JavaScript, TypeScript, and Vue (but support for these is available in WebStorm).
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ The following commands automatically become available:
 
 ### Editor
 > [!CAUTION]
-> IntelliJ IDEA currently has some major regressions with WSL support as of 2026.1. See []
-> While the usual advice is to use the latest versions, **do not upgrade to the 2026 series yet**.
+> 1. IntelliJ IDEA currently has some major regressions with WSL support as of 2026.1. See [KTIJ-38542].
+>    While the usual advice is to use the latest versions, **do not upgrade to the 2026 series yet**.
+> 2. There is currently a bug causing IntelliJ to saturate WSL's `/tmp` directory. See [IDEA-384441].
+>    You can run `just ij-wsl-clear` to prune files in `/tmp` and try again, restarting the IDE is not needed.
+>    As this is an aggressive workaround, you'll be prompted for confirmation.
 
 The project is configured for IntelliJ IDEA Ultimate. In other editions of IntelliJ IDEA, Spring support is limited
 and there is no support for JavaScript, TypeScript, and Vue (but support for these is available in WebStorm).
@@ -76,6 +79,9 @@ and there is no support for JavaScript, TypeScript, and Vue (but support for the
 > </details>
 
 If you're not using a JetBrains IDE, additional configuration might be required.
+
+[KTIJ-38542]: https://youtrack.jetbrains.com/issue/KTIJ-38542
+[IDEA-384441]: https://youtrack.jetbrains.com/issue/IDEA-384441
 
 ### Running the project
 You can run the project using `just start`, or via the run configurations available in IntelliJ (recommended).

--- a/commons/src/main/kotlin/org/elaastix/commons/jpa/AbstractEntity.kt
+++ b/commons/src/main/kotlin/org/elaastix/commons/jpa/AbstractEntity.kt
@@ -19,7 +19,6 @@
 
 package org.elaastix.commons.jpa
 
-import jakarta.persistence.Column
 import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import jakarta.persistence.PrePersist
@@ -30,11 +29,8 @@ import jakarta.validation.constraints.NotNull
 import org.elaastix.commons.data.Uuid
 import org.elaastix.commons.platform.JpaImmutable
 import org.hibernate.proxy.HibernateProxy
-import java.util.UUID
 import kotlin.time.Clock
 import kotlin.time.Instant
-import kotlin.uuid.toJavaUuid
-import kotlin.uuid.toKotlinUuid
 
 /**
  * Abstract class holding common properties shared by all entities.
@@ -45,20 +41,12 @@ import kotlin.uuid.toKotlinUuid
 @MappedSuperclass
 @Suppress("AbstractClassCanBeConcreteClass") // Don't want the class to be constructible.
 abstract class AbstractEntity {
-    // Use of a backing field is "required", as JPA doesn't allow AttributeConverters along with `@Id`...
-    // Doing it manually is an acceptable compromise; this logic is going to be reused universally.
-    // Note on performance of using a new UUID as default value: this is in fact not an issue since the no-arg
-    // constructor *does not initialise properties by default*! No useless generation happening when JPA constructs.
-    @Id
-    @Column(name = "id")
-    private var _id: UUID = Uuid.generateV7().toJavaUuid()
-        @JpaImmutable set
-
     /**
      * ID of the entity. The ID is a UUID v7 as specified by [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562.html).
      */
-    @delegate:Transient
-    val id: Uuid by lazy { _id.toKotlinUuid() }
+    @Id
+    var id: Uuid = Uuid.generateV7()
+        @JpaImmutable set
 
     /**
      * Date of creation of the entity (millisecond precision).
@@ -70,7 +58,7 @@ abstract class AbstractEntity {
     @delegate:Transient
     val createdAt by lazy {
         @Suppress("MagicNumber")
-        val timestamp = (_id.mostSignificantBits ushr 16) and 0xFFFFFFFFFFFFL
+        val timestamp = (id.toLongs { msb, _ -> msb ushr 16 }) and 0xFFFFFFFFFFFFL
         Instant.fromEpochMilliseconds(timestamp)
     }
 
@@ -117,7 +105,7 @@ abstract class AbstractEntity {
         val thisEffectiveClass = this.hibernateAwareJavaClass
         if (thisEffectiveClass != oEffectiveClass) return false
 
-        // Cast is safe; verified the class type.
+        // SAFETY: Cast is safe; verified the class type.
         return id == (other as AbstractEntity).id
     }
 

--- a/commons/src/main/kotlin/org/elaastix/commons/jpa/AbstractEntity.kt
+++ b/commons/src/main/kotlin/org/elaastix/commons/jpa/AbstractEntity.kt
@@ -19,17 +19,15 @@
 
 package org.elaastix.commons.jpa
 
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
-import jakarta.persistence.PrePersist
-import jakarta.persistence.PreUpdate
 import jakarta.persistence.Transient
 import jakarta.persistence.Version
 import jakarta.validation.constraints.NotNull
 import org.elaastix.commons.data.Uuid
 import org.elaastix.commons.platform.JpaImmutable
 import org.hibernate.proxy.HibernateProxy
-import kotlin.time.Clock
 import kotlin.time.Instant
 
 /**
@@ -39,6 +37,7 @@ import kotlin.time.Instant
  * All entities within Elaastix SHOULD inherit from AbstractEntity.
  */
 @MappedSuperclass
+@EntityListeners(EntityListener::class)
 @Suppress("AbstractClassCanBeConcreteClass") // Don't want the class to be constructible.
 abstract class AbstractEntity {
     /**
@@ -68,7 +67,7 @@ abstract class AbstractEntity {
      */
     @NotNull
     var updatedAt: Instant = createdAt
-        @JpaImmutable protected set
+        @JpaImmutable internal set
 
     @Version
     @NotNull
@@ -78,18 +77,6 @@ abstract class AbstractEntity {
     // https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a19
     @Suppress("UnusedPrivateMember")
     private var version: Long? = null
-
-    @PrePersist
-    @PreUpdate
-    // Actually used by JPA.
-    // Spec allow lifecycle callbacks to have any visibility, and only disallows `static` and `final`.
-    // https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#lifecycle-callback-methods
-    @Suppress("UnusedPrivateMember")
-    private fun updateTimestamp() {
-        // Implemented "by hand" to cope with the fact we're not using Java native types.
-        @OptIn(JpaImmutable::class)
-        updatedAt = Clock.System.now()
-    }
 
     /**
      * Checks if the entity is equal to [other].

--- a/commons/src/main/kotlin/org/elaastix/commons/jpa/EntityListener.kt
+++ b/commons/src/main/kotlin/org/elaastix/commons/jpa/EntityListener.kt
@@ -1,0 +1,32 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.commons.jpa
+
+import jakarta.persistence.PrePersist
+import org.elaastix.commons.platform.JpaImmutable
+import kotlin.time.Clock
+
+internal class EntityListener {
+    @PrePersist
+    fun prePersist(entity: AbstractEntity) {
+        @OptIn(JpaImmutable::class)
+        entity.updatedAt = Clock.System.now()
+    }
+}

--- a/commons/src/main/kotlin/org/elaastix/commons/jpa/JpaConverters.kt
+++ b/commons/src/main/kotlin/org/elaastix/commons/jpa/JpaConverters.kt
@@ -17,11 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@file:ExcludeFromCoverage("Converters are doing trivial conversions that are barely more than no-op")
+
 package org.elaastix.commons.jpa
 
 import jakarta.persistence.AttributeConverter
 import jakarta.persistence.Converter
 import org.elaastix.commons.data.Uuid
+import org.elaastix.commons.jpa.hibernate.UuidJavaType
+import org.elaastix.commons.platform.ExcludeFromCoverage
 import org.hibernate.boot.model.TypeContributions
 import org.hibernate.boot.model.TypeContributor
 import org.hibernate.service.ServiceRegistry
@@ -51,6 +55,9 @@ class HibernateTypeContributor : TypeContributor {
             initialised = true
             typeContributions.contributeAttributeConverter(UuidConverter::class.java)
             typeContributions.contributeAttributeConverter(InstantConverter::class.java)
+            typeContributions.contributeAttributeConverter(UIntConverter::class.java)
+            typeContributions.contributeAttributeConverter(ULongConverter::class.java)
+            typeContributions.contributeJavaType(UuidJavaType)
         }
     }
 }
@@ -61,9 +68,6 @@ class HibernateTypeContributor : TypeContributor {
  *
  * [UUID] is a [basic type](https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a486) that
  * JPA can deal with.
- *
- * **WARNING**: JPA [`@Id`][jakarta.persistence.Id] is **incompatible** with converters.
- * This incompatibility is dealt with by [AbstractEntity].
  */
 @Converter(autoApply = true)
 class UuidConverter : AttributeConverter<Uuid, UUID> {
@@ -85,4 +89,28 @@ class InstantConverter : AttributeConverter<Instant, JavaInstant> {
     override fun convertToDatabaseColumn(attribute: Instant?): JavaInstant? = attribute?.toJavaInstant()
 
     override fun convertToEntityAttribute(dbData: JavaInstant?): Instant? = dbData?.toKotlinInstant()
+}
+
+/**
+ * JPA Converter responsible for handling the conversion from [UInt] to [Int].
+ * Automatically applied, to allow seamless usage of [UInt] in entities.
+ */
+@Converter(autoApply = true)
+@ExcludeFromCoverage("Trivially equivalent to a no-op")
+class UIntConverter : AttributeConverter<UInt, Int> {
+    override fun convertToDatabaseColumn(attribute: UInt?): Int? = attribute?.toInt()
+
+    override fun convertToEntityAttribute(dbData: Int?): UInt? = dbData?.toUInt()
+}
+
+/**
+ * JPA Converter responsible for handling the conversion from [ULong] to [Long].
+ * Automatically applied, to allow seamless usage of [ULong] in entities.
+ */
+@Converter(autoApply = true)
+@ExcludeFromCoverage("Trivially equivalent to a no-op")
+class ULongConverter : AttributeConverter<ULong, Long> {
+    override fun convertToDatabaseColumn(attribute: ULong?): Long? = attribute?.toLong()
+
+    override fun convertToEntityAttribute(dbData: Long?): ULong? = dbData?.toULong()
 }

--- a/commons/src/main/kotlin/org/elaastix/commons/jpa/hibernate/UuidJavaType.kt
+++ b/commons/src/main/kotlin/org/elaastix/commons/jpa/hibernate/UuidJavaType.kt
@@ -1,0 +1,76 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.commons.jpa.hibernate
+
+import org.elaastix.commons.data.Uuid
+import org.hibernate.dialect.Dialect
+import org.hibernate.type.descriptor.WrapperOptions
+import org.hibernate.type.descriptor.java.AbstractClassJavaType
+import org.hibernate.type.descriptor.java.JavaType
+import org.hibernate.type.descriptor.java.UUIDJavaType
+import org.hibernate.type.descriptor.jdbc.JdbcType
+import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators
+import java.util.UUID
+import kotlin.uuid.toJavaUuid
+import kotlin.uuid.toKotlinUuid
+
+/**
+ * Hibernate [JavaType] to convert to and from Kotlin-native [Uuid].
+ */
+object UuidJavaType : AbstractClassJavaType<Uuid>(Uuid::class.java) {
+    override fun isInstance(value: Any) = value is Uuid
+
+    override fun cast(value: Any?) = value as Uuid?
+
+    override fun useObjectEqualsHashCode() = true
+
+    override fun getRecommendedJdbcType(context: JdbcTypeIndicators): JdbcType =
+        UUIDJavaType.INSTANCE.getRecommendedJdbcType(context)
+
+    override fun getDefaultSqlLength(dialect: Dialect, jdbcType: JdbcType): Long =
+        UUIDJavaType.INSTANCE.getDefaultSqlLength(dialect, jdbcType)
+
+    override fun toString(value: Uuid): String = value.toHexDashString()
+
+    override fun fromString(string: CharSequence): Uuid = Uuid.parse(string.toString())
+
+    override fun <X> unwrap(value: Uuid?, type: Class<X>, options: WrapperOptions): X? =
+        value?.let {
+            when {
+                UUID::class.java.isAssignableFrom(type) -> type.cast(it.toJavaUuid())
+                String::class.java.isAssignableFrom(type) -> type.cast(it.toHexDashString())
+                ByteArray::class.java.isAssignableFrom(type) -> type.cast(it.toByteArray())
+                else -> throw unknownUnwrap(type)
+            }
+        }
+
+    override fun <X> wrap(value: X, options: WrapperOptions): Uuid? =
+        when (value) {
+            null -> null
+            is Uuid -> value
+            is UUID -> value.toKotlinUuid()
+            is String -> Uuid.parse(value)
+            is ByteArray -> Uuid.fromByteArray(value)
+            else -> throw unknownWrap(value::class.java)
+        }
+
+    @Suppress("unused") // https://jetbrains.com/help/inspectopedia/JavaIoSerializableObjectMustHaveReadResolve.html
+    private fun readResolve(): Any = UuidJavaType
+}

--- a/commons/src/main/kotlin/org/elaastix/commons/platform/ExcludeFromCoverage.kt
+++ b/commons/src/main/kotlin/org/elaastix/commons/platform/ExcludeFromCoverage.kt
@@ -26,7 +26,7 @@ package org.elaastix.commons.platform
  */
 @Suppress("unused") // Used by humans ;)
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.FILE)
 annotation class ExcludeFromCoverage(
     /** Explanation as to why the class or function is being excluded from code coverage calculations. */
     val message: String,


### PR DESCRIPTION
Dealing with Java v. Kotlin's uuid type doesn't play well with `Repository` and all the magic things Spring/Hibernate try to do because they're essentially blind to the conversion.

Add attribute converters for `UInt` and `ULong` too so Hibernate doesn't panic when encountering proper numeric types. :)

Cherry-picked fixes from #204