### PR TITLE
refactor: split SciconumSequenceEntity, nullability constraints

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -12,6 +12,7 @@
       <w>elaastic</w>
       <w>elaastix</w>
       <w>hypersistence's</w>
+      <w>ktij</w>
       <w>ktlint</w>
       <w>nsid</w>
       <w>sciconum</w>

--- a/Justfile
+++ b/Justfile
@@ -54,7 +54,7 @@ stop:
 @openapi:
 	?[ "${SKIP_OPENAPI_GENERATION:-}" != "true" ]
 	-rm server/build/openapi.json 2>/dev/null
-	just sidecar gradle :server:bootRun --args=\"--spring.profiles.active=develop --spring.flyway.enable=false --logging.level.root=WARN --debug=false --server.port=0 --generate-openapi='`pwd`/server/build/openapi.json'\"
+	just sidecar gradle :server:bootRun --args=\"--spring.profiles.active=develop,openapi\"
 	test -f server/build/openapi.json
 
 [group('dependencies')]

--- a/server/src/main/kotlin/org/elaastix/server/OpenApiCommandLineRunner.kt
+++ b/server/src/main/kotlin/org/elaastix/server/OpenApiCommandLineRunner.kt
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory
 import org.springdoc.webmvc.api.OpenApiResource
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.CommandLineRunner
+import org.springframework.context.annotation.Profile
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
@@ -38,36 +39,37 @@ import kotlin.system.exitProcess
  * Best used via `just openapi`.
  */
 @Component
+@Profile("openapi")
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class OpenApiCommandLineRunner(
-	@Value($$"${generate-openapi:#{null}}")
-	private val generationPath: String?,
+	@Value($$"${generation-path}")
+	private val generationPath: String,
 	private val openApiResource: OpenApiResource,
 ) : CommandLineRunner {
 	override fun run(vararg args: String) {
-		if (generationPath != null) {
-			val logger = LoggerFactory.getLogger(this::class.java)
+		val logger = LoggerFactory.getLogger(this::class.java)
+		logger.info("Generating OpenAPI specification. The server will exit once this is complete.")
 
-			logger.info("Generating OpenAPI specification. The server will exit once this is complete.")
+		val json = generate()
+		val file = File(generationPath)
+		val os = file.outputStream()
+		os.write(json)
+		os.close()
 
-			// It's protected. And putting together a fake HttpServletRequest is worse. Deal with it. >:(
-			val clazz = OpenApiResource::class.java.superclass
-			val getSpec = clazz.getDeclaredMethod("getOpenApi", String::class.java, Locale::class.java)
-			getSpec.trySetAccessible()
+		logger.info("Specification written to ${file.absolutePath}. Bye.")
+		exitProcess(0)
+	}
 
-			val writeJsonValue = clazz.getDeclaredMethod("writeJsonValue", OpenAPI::class.java)
-			writeJsonValue.trySetAccessible()
+	private fun generate(): ByteArray {
+		// It's protected. And putting together a fake HttpServletRequest is worse. Deal with it. >:(
+		val clazz = OpenApiResource::class.java.superclass
+		val getSpec = clazz.getDeclaredMethod("getOpenApi", String::class.java, Locale::class.java)
+		getSpec.trySetAccessible()
 
-			val spec = getSpec.invoke(openApiResource, "", Locale.UK) as OpenAPI
-			val json = writeJsonValue.invoke(openApiResource, spec) as ByteArray
+		val writeJsonValue = clazz.getDeclaredMethod("writeJsonValue", OpenAPI::class.java)
+		writeJsonValue.trySetAccessible()
 
-			val file = File(generationPath)
-			val os = file.outputStream()
-			os.write(json)
-			os.close()
-
-			logger.info("Specification written to ${file.absolutePath}. Bye.")
-			exitProcess(0)
-		}
+		val spec = getSpec.invoke(openApiResource, "", Locale.UK) as OpenAPI
+		return writeJsonValue.invoke(openApiResource, spec) as ByteArray
 	}
 }

--- a/server/src/main/kotlin/org/elaastix/server/activities/response/entities/ClosedQuestionEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/activities/response/entities/ClosedQuestionEntity.kt
@@ -27,6 +27,7 @@ import org.elaastix.mm.content.RichContent
 import org.elaastix.server.activities.response.ClosedAnswer
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import org.jetbrains.annotations.NotNull
 
 /** A closed question. */
 @Entity
@@ -38,13 +39,16 @@ class ClosedQuestionEntity(
 	 * The available choices presented to the questionee.
 	 * Whether they are shown in order depends on the specific configuration of the activity this question is used in.
 	 */
+	@NotNull
 	@JdbcTypeCode(SqlTypes.JSON)
 	var choices: List<FormattedText>,
 
 	/** Whether the question accepts multiple answers or not. */
+	@NotNull
 	var multiple: Boolean,
 
 	/** The expected answer. */
+	@NotNull
 	@JdbcTypeCode(SqlTypes.JSON)
 	@Suppress("JpaAttributeTypeInspection") // IDEA-191568
 	var expectedAnswer: ClosedAnswer,

--- a/server/src/main/kotlin/org/elaastix/server/activities/response/entities/ClosedResponseEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/activities/response/entities/ClosedResponseEntity.kt
@@ -26,6 +26,7 @@ import org.elaastix.mm.content.FormattedContent
 import org.elaastix.server.activities.response.ClosedAnswer
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import org.jetbrains.annotations.NotNull
 
 /** Answer to a [ClosedQuestionEntity]. */
 @Entity
@@ -34,6 +35,7 @@ class ClosedResponseEntity(
 	question: ClosedQuestionEntity,
 
 	/** The answer given by the learner. May be empty, but is required. */
+	@NotNull
 	@JdbcTypeCode(SqlTypes.JSON)
 	@Suppress("JpaAttributeTypeInspection") // IDEA-191568
 	var answer: ClosedAnswer,

--- a/server/src/main/kotlin/org/elaastix/server/activities/response/entities/OpenQuestionEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/activities/response/entities/OpenQuestionEntity.kt
@@ -25,6 +25,7 @@ import org.elaastix.mm.content.FormattedContent
 import org.elaastix.mm.content.RichContent
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import org.jetbrains.annotations.NotNull
 
 /** An open question. */
 @Entity
@@ -41,6 +42,7 @@ class OpenQuestionEntity(
 	 * It would be unfair to expect an answer with formatting that the learners are unable to use; it forces the
 	 * question author to put themselves in the student's shoes while preparing the questions.
 	 */
+	@NotNull
 	@JdbcTypeCode(SqlTypes.JSON)
 	@Suppress("JpaAttributeTypeInspection") // IDEA-191568
 	var expectedAnswer: FormattedContent,

--- a/server/src/main/kotlin/org/elaastix/server/activities/response/entities/OpenResponseEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/activities/response/entities/OpenResponseEntity.kt
@@ -25,6 +25,7 @@ import org.elaastix.mm.activity.ScalarGrade
 import org.elaastix.mm.content.FormattedContent
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import org.jetbrains.annotations.NotNull
 
 /** Answer to a [OpenQuestionEntity]. */
 @Entity
@@ -33,6 +34,7 @@ class OpenResponseEntity(
 	question: OpenQuestionEntity,
 
 	/** The answer given by the learner. May be empty, but is required. */
+	@NotNull
 	@JdbcTypeCode(SqlTypes.JSON)
 	@Suppress("JpaAttributeTypeInspection") // IDEA-191568
 	var answer: FormattedContent,

--- a/server/src/main/kotlin/org/elaastix/server/activities/response/entities/QuestionEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/activities/response/entities/QuestionEntity.kt
@@ -27,6 +27,7 @@ import org.elaastix.mm.content.RichContent
 import org.elaastix.server.core.AbstractEntityWithAuthorship
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import org.jetbrains.annotations.NotNull
 
 /**
  * Generic question. Lacks important properties that are defined by subclasses.
@@ -35,6 +36,7 @@ import org.hibernate.type.SqlTypes
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 abstract class QuestionEntity(
 	/** The question's statement. */
+	@NotNull
 	@JdbcTypeCode(SqlTypes.JSON)
 	@Suppress("JpaAttributeTypeInspection") // IDEA-191568
 	var statement: RichContent,

--- a/server/src/main/kotlin/org/elaastix/server/activities/response/entities/ResponseEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/activities/response/entities/ResponseEntity.kt
@@ -31,6 +31,7 @@ import org.elaastix.mm.content.FormattedContent
 import org.elaastix.server.core.AbstractEntityWithAuthorship
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
+import org.jetbrains.annotations.NotNull
 
 /**
  * Generic response. Lacks important properties that are defined by subclasses.
@@ -39,6 +40,7 @@ import org.hibernate.type.SqlTypes
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 abstract class ResponseEntity<TSelf : ResponseEntity<TSelf, TQuestion>, TQuestion : QuestionEntity>(
 	/** The question this response is attached to. */
+	@NotNull
 	@ManyToOne(targetEntity = QuestionEntity::class)
 	var question: TQuestion,
 

--- a/server/src/main/kotlin/org/elaastix/server/core/AbstractEntityWithAuthorship.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/AbstractEntityWithAuthorship.kt
@@ -25,6 +25,7 @@ import org.elaastix.commons.jpa.entity.AbstractEntity
 import org.elaastix.commons.platform.JpaImmutable
 import org.elaastix.commons.platform.wip.UnclearAuthorshipOwnership
 import org.elaastix.server.users.entities.UserEntity
+import org.jetbrains.annotations.NotNull
 import org.springframework.data.annotation.CreatedBy
 
 /**
@@ -38,9 +39,10 @@ abstract class AbstractEntityWithAuthorship : AbstractEntity() {
 	/**
 	 * The original author.
 	 */
-	@property:UnclearAuthorshipOwnership
+	@NotNull
 	@CreatedBy
 	@ManyToOne
+	@property:UnclearAuthorshipOwnership
 	lateinit var author: UserEntity
 		@JpaImmutable set
 }

--- a/server/src/main/kotlin/org/elaastix/server/core/infrastructure/config/JpaAuditConfig.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/infrastructure/config/JpaAuditConfig.kt
@@ -1,0 +1,42 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.core.infrastructure.config
+
+import org.elaastix.server.users.entities.UserEntity
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.Optional
+
+/**
+ * Configuration for Spring Data's JPA auditing.
+ * See https://docs.spring.io/spring-data/jpa/reference/auditing.html#auditing.auditor-aware
+ */
+@Configuration
+@EnableJpaAuditing
+class JpaAuditConfig : AuditorAware<UserEntity> {
+	override fun getCurrentAuditor(): Optional<UserEntity> =
+		Optional.ofNullable(
+			SecurityContextHolder.getContext().authentication
+				?.takeIf { it.isAuthenticated }
+				?.let { it.principal as? UserEntity? },
+		)
+}

--- a/server/src/main/kotlin/org/elaastix/server/core/infrastructure/config/SecurityConfiguration.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/infrastructure/config/SecurityConfiguration.kt
@@ -21,17 +21,14 @@ package org.elaastix.server.core.infrastructure.config
 
 import org.elaastix.server.authn.ElaastixAuthenticationFilter
 import org.elaastix.server.authn.ElaastixAuthenticationProvider
-import org.elaastix.server.users.entities.UserEntity
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.domain.AuditorAware
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter
@@ -39,7 +36,6 @@ import org.springframework.security.web.util.matcher.AnyRequestMatcher
 import org.springframework.web.servlet.HandlerExceptionResolver
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
-import java.util.Optional
 
 /**
  * Configuration for Spring Security features.
@@ -50,19 +46,7 @@ import java.util.Optional
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
-class SecurityConfiguration :
-	WebMvcConfigurer,
-	AuditorAware<UserEntity> {
-	/**
-	 * See https://docs.spring.io/spring-data/jpa/reference/auditing.html#auditing.auditor-aware
-	 */
-	override fun getCurrentAuditor(): Optional<UserEntity> =
-		Optional.ofNullable(
-			SecurityContextHolder.getContext().authentication
-				?.takeIf { it.isAuthenticated }
-				?.let { it.principal as? UserEntity? },
-		)
-
+class SecurityConfiguration : WebMvcConfigurer {
 	override fun addCorsMappings(registry: CorsRegistry) {
 		registry.addMapping("/openapi.json")
 	}

--- a/server/src/main/kotlin/org/elaastix/server/core/infrastructure/seed/Seeder.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/infrastructure/seed/Seeder.kt
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component
  * Custom stereotype for database seeders.
  */
 @Component
-@Profile("develop")
+@Profile("develop & !openapi")
 @ConditionalOnMissingClass("testutils.WithMockUser")
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/server/src/main/kotlin/org/elaastix/server/sequences/SciconumSequenceEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/sequences/SciconumSequenceEntity.kt
@@ -20,37 +20,30 @@
 package org.elaastix.server.sequences
 
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
-import jakarta.persistence.Inheritance
-import jakarta.persistence.InheritanceType
-import jakarta.persistence.ManyToOne
-import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Size
-import org.elaastix.commons.jpa.entity.AbstractEntity
-import org.elaastix.commons.platform.wip.UnclearAuthorshipOwnership
-import org.elaastix.server.users.entities.UserEntity
-import org.springframework.data.annotation.CreatedBy
+import jakarta.persistence.ManyToMany
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.server.activities.response.entities.QuestionEntity
+import org.elaastix.server.scenario.SciconumScenario
 
-/**
- * A pedagogical sequence.
- * TODO: Extensive description of the concept.
- */
 @Entity
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-open class SequenceEntity(
+@SciconumTechDebt
+class SciconumSequenceEntity(
+	name: String,
+
 	/**
-	 * Display name of the sequence.
+	 * SCICONUM scenario of the sequence.
 	 */
-	@NotNull
-	@Size(min = 2, max = 64)
-	var name: String,
-) : AbstractEntity() {
+	@property:SciconumTechDebt
+	@Enumerated(EnumType.STRING)
+	var sciconumScenario: SciconumScenario,
+
 	/**
-	 * Owner of the resource, but not necessarily its author per se.
+	 * Question for the SCICONUM sequence.
 	 */
-	@NotNull
-	@CreatedBy
-	@ManyToOne(fetch = FetchType.LAZY)
-	@property:UnclearAuthorshipOwnership
-	lateinit var owner: UserEntity
-}
+	@property:SciconumTechDebt
+	@ManyToMany(fetch = FetchType.EAGER)
+	var sciconumQuestions: MutableSet<QuestionEntity>,
+) : SequenceEntity(name)

--- a/server/src/main/kotlin/org/elaastix/server/sequences/SequenceEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/sequences/SequenceEntity.kt
@@ -25,6 +25,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.ManyToMany
 import jakarta.persistence.ManyToOne
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.elaastix.commons.jpa.entity.AbstractEntity
 import org.elaastix.commons.platform.debt.SciconumTechDebt
@@ -43,28 +44,31 @@ class SequenceEntity @SciconumTechDebt constructor(
 	/**
 	 * Display name of the sequence.
 	 */
+	@NotNull
 	@Size(min = 2, max = 64)
 	var name: String,
 
 	/**
 	 * SCICONUM scenario of the sequence.
 	 */
-	@property:SciconumTechDebt
+	@NotNull
 	@Enumerated(EnumType.STRING)
+	@property:SciconumTechDebt
 	var sciconumScenario: SciconumScenario,
 
 	/**
 	 * Question for the SCICONUM sequence.
 	 */
-	@property:SciconumTechDebt
 	@ManyToMany(fetch = FetchType.EAGER)
+	@property:SciconumTechDebt
 	var sciconumQuestions: MutableSet<QuestionEntity>,
 ) : AbstractEntity() {
 	/**
 	 * Owner of the resource, but not necessarily its author per se.
 	 */
-	@property:UnclearAuthorshipOwnership
-	@ManyToOne(fetch = FetchType.LAZY)
+	@NotNull
 	@CreatedBy
+	@ManyToOne(fetch = FetchType.LAZY)
+	@property:UnclearAuthorshipOwnership
 	lateinit var owner: UserEntity
 }

--- a/server/src/main/kotlin/org/elaastix/server/sequences/SequenceService.kt
+++ b/server/src/main/kotlin/org/elaastix/server/sequences/SequenceService.kt
@@ -47,8 +47,17 @@ class SequenceService(
 ) {
 	companion object {
 		/** Maps a [SequenceEntity] to a [SequenceDto]. */
-		@OptIn(SciconumTechDebt::class, UnclearAuthorshipOwnership::class)
+		@OptIn(SciconumTechDebt::class)
 		fun SequenceEntity.toDto(): SequenceDto =
+			when (this) {
+				is SciconumSequenceEntity -> toDto()
+				else -> throw NotImplementedError()
+			}
+
+		/** Maps a [SciconumSequenceEntity] to a [SequenceDto]. */
+		@SciconumTechDebt
+		@OptIn(UnclearAuthorshipOwnership::class)
+		fun SciconumSequenceEntity.toDto(): SequenceDto =
 			SequenceDto(
 				id = id,
 				name = name,
@@ -82,6 +91,7 @@ class SequenceService(
 	 * @return The requested sequence.
 	 */
 	@Transactional(readOnly = true)
+	@OptIn(SciconumTechDebt::class)
 	fun getSequence(id: Uuid): SequenceDto = sequenceRepository.findById(id).orNotFound().toDto()
 
 	/**
@@ -93,10 +103,10 @@ class SequenceService(
 	 * @return The created entity.
 	 */
 	@Transactional
+	@OptIn(SciconumTechDebt::class)
 	fun createSequence(@Valid dto: CreateSequenceDto): SequenceDto {
 		val entity = sequenceRepository.persist(
-			@OptIn(SciconumTechDebt::class)
-			SequenceEntity(
+			SciconumSequenceEntity(
 				name = dto.name,
 				sciconumScenario = dto.sciconumScenario,
 				sciconumQuestions = dto.sciconumQuestionIds.toRefSet(questionRepository),
@@ -116,14 +126,13 @@ class SequenceService(
 	 * @return The updated entity.
 	 */
 	@Transactional
+	@OptIn(SciconumTechDebt::class)
 	fun updateSequence(id: Uuid, @Valid dto: UpdateSequenceDto): SequenceDto {
 		val entity = sequenceRepository.findByIdAndUpdate(id) {
+			if (this !is SciconumSequenceEntity) throw NotImplementedError()
+
 			dto.name.takeIfUpdated { name = it }
-
-			@OptIn(SciconumTechDebt::class)
 			dto.sciconumScenario.takeIfUpdated { sciconumScenario = it }
-
-			@OptIn(SciconumTechDebt::class)
 			dto.sciconumQuestionIds.takeIfUpdated { sciconumQuestions = it.toRefSet(questionRepository) }
 		}
 

--- a/server/src/main/resources/application-openapi.yaml
+++ b/server/src/main/resources/application-openapi.yaml
@@ -1,0 +1,9 @@
+debug: false
+server.port: 0
+spring.jpa.hibernate.ddl-auto: none
+spring.flyway.enabled: false
+
+logging.level.root: WARN
+logging.level.org.elaastix.server: INFO
+
+generation-path: build/openapi.json

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ spring:
 
   jpa:
     open-in-view: false
+    hibernate.ddl-auto: validate
     properties.hibernate:
       jdbc.batch_size: 10
       order_inserts: true

--- a/server/src/main/resources/db/migration/V4__update_response_and_not_null_constraints.sql
+++ b/server/src/main/resources/db/migration/V4__update_response_and_not_null_constraints.sql
@@ -1,0 +1,53 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ALTER TABLE response_entity
+	ADD grade DOUBLE PRECISION;
+
+ALTER TABLE response_entity
+	ADD max DOUBLE PRECISION;
+
+ALTER TABLE response_entity
+	ALTER COLUMN grade SET NOT NULL;
+
+ALTER TABLE response_entity
+	ALTER COLUMN max SET NOT NULL;
+
+-- Forgotten null constraints in V2
+
+ALTER TABLE response_entity
+	ALTER COLUMN question_id SET NOT NULL;
+
+ALTER TABLE response_entity
+	ALTER COLUMN author_id SET NOT NULL;
+
+ALTER TABLE response_entity
+	ALTER COLUMN answer SET NOT NULL;
+
+ALTER TABLE question_entity
+	ALTER COLUMN statement SET NOT NULL;
+
+ALTER TABLE question_entity
+	ALTER COLUMN author_id SET NOT NULL;
+
+ALTER TABLE question_entity
+	ALTER COLUMN choices SET NOT NULL;
+
+ALTER TABLE question_entity
+	ALTER COLUMN expected_answer SET NOT NULL;

--- a/server/src/main/resources/db/migration/V5__create_sequence_entity.sql
+++ b/server/src/main/resources/db/migration/V5__create_sequence_entity.sql
@@ -36,18 +36,6 @@ CREATE TABLE sequence_entity_sciconum_questions
 	CONSTRAINT pk_sequenceentity_sciconumquestions PRIMARY KEY (sciconum_sequence_entity_id, sciconum_questions_id)
 );
 
-ALTER TABLE response_entity
-	ADD grade DOUBLE PRECISION;
-
-ALTER TABLE response_entity
-	ADD max DOUBLE PRECISION;
-
-ALTER TABLE response_entity
-	ALTER COLUMN grade SET NOT NULL;
-
-ALTER TABLE response_entity
-	ALTER COLUMN max SET NOT NULL;
-
 ALTER TABLE sequence_entity
 	ADD CONSTRAINT FK_SEQUENCEENTITY_ON_OWNER FOREIGN KEY (owner_id) REFERENCES users (id);
 

--- a/server/src/main/resources/db/migration/V5__create_sequence_entity.sql
+++ b/server/src/main/resources/db/migration/V5__create_sequence_entity.sql
@@ -1,0 +1,58 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+CREATE TABLE sequence_entity
+(
+	id                UUID                        NOT NULL,
+	dtype             VARCHAR(31)                 NOT NULL,
+	updated_at        TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+	version           BIGINT                      NOT NULL,
+	name              VARCHAR(64)                 NOT NULL,
+	owner_id          UUID                        NOT NULL,
+	sciconum_scenario VARCHAR(255),
+	CONSTRAINT pk_sequenceentity PRIMARY KEY (id)
+);
+
+CREATE TABLE sequence_entity_sciconum_questions
+(
+	sciconum_sequence_entity_id UUID NOT NULL,
+	sciconum_questions_id       UUID NOT NULL,
+	CONSTRAINT pk_sequenceentity_sciconumquestions PRIMARY KEY (sciconum_sequence_entity_id, sciconum_questions_id)
+);
+
+ALTER TABLE response_entity
+	ADD grade DOUBLE PRECISION;
+
+ALTER TABLE response_entity
+	ADD max DOUBLE PRECISION;
+
+ALTER TABLE response_entity
+	ALTER COLUMN grade SET NOT NULL;
+
+ALTER TABLE response_entity
+	ALTER COLUMN max SET NOT NULL;
+
+ALTER TABLE sequence_entity
+	ADD CONSTRAINT FK_SEQUENCEENTITY_ON_OWNER FOREIGN KEY (owner_id) REFERENCES users (id);
+
+ALTER TABLE sequence_entity_sciconum_questions
+	ADD CONSTRAINT fk_seqentscique_on_question_entity FOREIGN KEY (sciconum_questions_id) REFERENCES question_entity (id);
+
+ALTER TABLE sequence_entity_sciconum_questions
+	ADD CONSTRAINT fk_seqentscique_on_sciconum_sequence_entity FOREIGN KEY (sciconum_sequence_entity_id) REFERENCES sequence_entity (id);


### PR DESCRIPTION
Also fixes an issue with JPA auditing not being properly configured and not setting `CreatedBy` appropriately.

Hibernate's DDL validation has been enabled to detect missing migrations and fail with an explicit error instead of an implicit persistence operation failure.