### PR TITLE
feat: session execution through time

### DIFF
--- a/.config/detekt/detekt.yaml
+++ b/.config/detekt/detekt.yaml
@@ -65,8 +65,8 @@ style:
         reason: Use org.elaastix.commons.data.Uuid instead
       - value: kotlin.uuid.Uuid
         reason: Use org.elaastix.commons.data.Uuid instead
-      - value: java.time.Instant
-        reason: Use Kotlin's Instant type
+      - value: java.time.*
+        reason: Use kotlin.time.* instead
       # Ban Spring Security's helper as we have our own
       - value: org.springframework.security.test.context.support.WithMockUser
         reason: Use testutils.WithMockUser instead
@@ -76,8 +76,10 @@ style:
       - value: org.junit.jupiter.api.TestMethodOrder
         reason: Banned annotation. Tests are run in a randomised order to help fuzzing against race conditions.
     excludes:
-      - "**/commons/jpa/**"     # Compat layer
-      - "**/commons/data/Uuid.kt"  # Uuid type alias
+      - "**/commons/jpa/**"                                        # Compat layer
+      - "**/commons/data/Uuid.kt"                                  # Uuid type alias
+      - "**/server/core/infrastructure/config/SchedulerConfig.kt"  # Java Clock glue code
+      - "**/testutils/ControllableClock.kt"                        # Java Clock glue code
   AbstractClassCanBeConcreteClass:
     active: false
   VarCouldBeVal:

--- a/build-logic/src/main/kotlin/Helpers.kt
+++ b/build-logic/src/main/kotlin/Helpers.kt
@@ -18,22 +18,25 @@
  */
 
 @file:Suppress(
+	"TooManyFunctions",
 	"UnusedReceiverParameter",
 	"UndocumentedPublicClass",
 	"UndocumentedPublicFunction",
 	"UndocumentedPublicProperty",
 	"FunctionOnlyReturningConstant",
 	"SpellCheckingInspection",
+	"UnstableApiUsage",
 )
 
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.plugins.jvm.JvmComponentDependencies
 import org.gradle.kotlin.dsl.DependencyHandlerScope
 
-private fun depWithVersion(dep: String, version: String?): Any =
+private fun depWithVersion(dep: String, version: String?) =
 	"$dep${version?.let { ":$version" } ?: ""}"
 
-private fun depWithModule(prefix: String, module: String, version: String? = null): Any =
+private fun depWithModule(prefix: String, module: String, version: String? = null) =
 	depWithVersion(
 		when (module) {
 			"" -> prefix
@@ -44,35 +47,48 @@ private fun depWithModule(prefix: String, module: String, version: String? = nul
 
 // Extra "well-known" shortcuts for common sources
 
+object SpringDependencyShortcuts {
+	object SpringStarterShortcut {
+		operator fun invoke(module: String = "", version: String? = null) =
+			depWithModule("org.springframework.boot:spring-boot-starter", module, version)
+
+		fun test(module: String = "", version: String? = null) =
+			depWithVersion("${invoke(module)}-test", version)
+	}
+
+	operator fun invoke(module: String, version: String? = null) =
+		depWithModule("org.springframework:spring", module, version)
+	fun data(module: String, version: String? = null) =
+		depWithModule("org.springframework.data:spring-data", module, version)
+	fun security(module: String, version: String? = null) =
+		depWithModule("org.springframework.security:spring-security", module, version)
+	fun boot(module: String = "", version: String? = null) =
+		depWithModule("org.springframework.boot:spring-boot", module, version)
+
+	val starter = SpringStarterShortcut
+}
+
 fun DependencyHandler.kotlinx(module: String, version: String? = null) =
 	depWithVersion("org.jetbrains.kotlinx:kotlinx-$module", version)
 
 fun DependencyHandler.jakarta(module: String, version: String? = null) =
 	depWithVersion("jakarta.$module:jakarta.$module-api", version)
 
-object SpringDependencyShortcuts {
-	object SpringStarterShortcut {
-		operator fun invoke(module: String = "", version: String? = null): Any =
-			depWithModule("org.springframework.boot:spring-boot-starter", module, version)
-
-		fun test(module: String = "", version: String? = null): Any =
-			depWithVersion("${invoke(module)}-test", version)
-	}
-
-	operator fun invoke(module: String, version: String? = null): Any =
-		depWithModule("org.springframework:spring", module, version)
-	fun data(module: String, version: String? = null): Any =
-		depWithModule("org.springframework.data:spring-data", module, version)
-	fun security(module: String, version: String? = null): Any =
-		depWithModule("org.springframework.security:spring-security", module, version)
-	fun boot(module: String = "", version: String? = null): Any =
-		depWithModule("org.springframework.boot:spring-boot", module, version)
-
-	val starter = SpringStarterShortcut
-}
-
 val DependencyHandler.spring: SpringDependencyShortcuts
 	get() = SpringDependencyShortcuts
+
+fun JvmComponentDependencies.kotlin(module: String, version: String? = null) =
+	depWithVersion("org.jetbrains.kotlin:kotlin-$module", version)
+
+fun JvmComponentDependencies.kotlinx(module: String, version: String? = null) =
+	depWithVersion("org.jetbrains.kotlinx:kotlinx-$module", version)
+
+fun JvmComponentDependencies.jakarta(module: String, version: String? = null) =
+	depWithVersion("jakarta.$module:jakarta.$module-api", version)
+
+val JvmComponentDependencies.spring: SpringDependencyShortcuts
+	get() = SpringDependencyShortcuts
+
 
 /**
  * Helper for adding a Spring Boot starter to the dependencies.
@@ -94,3 +110,6 @@ fun DependencyHandlerScope.testSpringBootStarter(starter: String) = springBootSt
 
 internal fun VersionCatalog.version(id: String) = findVersion(id).get().toString()
 internal fun DependencyHandlerScope.bom(specifier: Any) = add("implementation", enforcedPlatform(specifier))
+
+internal fun JvmComponentDependencies.bom(specifier: CharSequence) =
+	implementation.add(enforcedPlatform.modify(specifier))

--- a/build-logic/src/main/kotlin/conventions/kotlin.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/kotlin.gradle.kts
@@ -24,6 +24,7 @@ import dev.detekt.gradle.Detekt
 import kotlinx
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import version
 
 val libs = the<VersionCatalogsExtension>().named("libs")
@@ -84,6 +85,7 @@ detekt {
 dependencies {
 	bom(kotlin("bom", version = libs.version("kotlin")))
 	bom(kotlinx("serialization-bom", version = libs.version("kotlinx-serialization")))
+	bom(SpringBootPlugin.BOM_COORDINATES)
 
 	implementation(kotlin("stdlib"))
 	implementation(kotlinx("serialization-core"))

--- a/build-logic/src/main/kotlin/conventions/spring.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/spring.gradle.kts
@@ -37,7 +37,6 @@ plugins {
 }
 
 dependencies {
-	bom(SpringBootPlugin.BOM_COORDINATES)
 	implementation(kotlin("reflect"))
 
 	implementation(jakarta("persistence"))

--- a/build-logic/src/main/kotlin/conventions/test.gradle.kts
+++ b/build-logic/src/main/kotlin/conventions/test.gradle.kts
@@ -21,7 +21,11 @@
 
 package conventions
 
+import bom
+import kotlinx
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import version
+import kotlin
 
 val libs = the<VersionCatalogsExtension>().named("libs")
 
@@ -44,8 +48,13 @@ testing {
 			useJUnitJupiter(libs.version("junit"))
 
 			dependencies {
+				bom(kotlin("bom", version = libs.version("kotlin")))
+				bom(kotlinx("serialization-bom", version = libs.version("kotlinx-serialization")))
+				bom(SpringBootPlugin.BOM_COORDINATES)
+
 				implementation(project())
-				implementation(libs.findLibrary("assertj").get())
+				implementation("org.assertj:assertj-core")
+				// implementation("org.awaitility:awaitility")
 			}
 		}
 

--- a/commons/core/src/main/kotlin/org/elaastix/commons/CollectionCreateUtils.kt
+++ b/commons/core/src/main/kotlin/org/elaastix/commons/CollectionCreateUtils.kt
@@ -1,0 +1,114 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("TooManyFunctions", "Unused")
+
+package org.elaastix.commons
+
+/**
+ * Creates a mutable list of size [size], populating it by calling [factory] for each value.
+ */
+inline fun <T> makeList(size: Int, factory: (Int) -> T): MutableList<T> =
+	mutableListOf<T>().apply { repeat(size) { add(factory(it)) } }
+
+/**
+ * Creates a mutable list of size [size], populating it by calling [factory] for each value.
+ */
+inline fun <T> makeList(size: UInt, factory: (UInt) -> T): MutableList<T> =
+	mutableListOf<T>().apply { repeat(size.toInt()) { add(factory(it.toUInt())) } }
+
+/**
+ * Creates a mutable list of size [size], populating it by calling [factory] for each value.
+ * Variant that doesn't pass the index of current iteration to the factory.
+ * Named differently to avoid issues with overload resolution. KT-18451
+ */
+inline fun <T> makeListN(size: Int, factory: () -> T): MutableList<T> =
+	mutableListOf<T>().apply { repeat(size) { add(factory()) } }
+
+/**
+ * Creates a mutable list of size [size], populating it by calling [factory] for each value.
+ * Variant that doesn't pass the index of current iteration to the factory.
+ * Named differently to avoid issues with overload resolution. KT-18451
+ */
+inline fun <T> makeListN(size: UInt, factory: () -> T): MutableList<T> =
+	mutableListOf<T>().apply { repeat(size.toInt()) { add(factory()) } }
+
+/**
+ * Creates a mutable set of size [size], populating it by calling [factory] for each value.
+ * The resulting set will not be of the specified size if there are duplicate values returned by the factory.
+ */
+inline fun <T> makeSet(size: Int, factory: (Int) -> T): MutableSet<T> =
+	mutableSetOf<T>().apply { repeat(size) { add(factory(it)) } }
+
+/**
+ * Creates a mutable set of size [size], populating it by calling [factory] for each value.
+ * The resulting set will not be of the specified size if there are duplicate values returned by the factory.
+ */
+inline fun <T> makeSet(size: UInt, factory: (Int) -> T): MutableSet<T> =
+	mutableSetOf<T>().apply { repeat(size.toInt()) { add(factory(it)) } }
+
+/**
+ * Creates a mutable set of size [size], populating it by calling [factory] for each value.
+ * The resulting set will not be of the specified size if there are duplicate values returned by the factory.
+ * Variant that doesn't pass the index of current iteration to the factory.
+ * Named differently to avoid issues with overload resolution. KT-18451
+ */
+inline fun <T> makeSetN(size: Int, factory: () -> T): MutableSet<T> =
+	mutableSetOf<T>().apply { repeat(size) { add(factory()) } }
+
+/**
+ * Creates a mutable set of size [size], populating it by calling [factory] for each value.
+ * The resulting set will not be of the specified size if there are duplicate values returned by the factory.
+ * Variant that doesn't pass the index of current iteration to the factory.
+ * Named differently to avoid issues with overload resolution. KT-18451
+ */
+inline fun <T> makeSetN(size: UInt, factory: () -> T): MutableSet<T> =
+	mutableSetOf<T>().apply { repeat(size.toInt()) { add(factory()) } }
+
+/**
+ * Creates a mutable map of size [size], populating it by calling [factory] for each value.
+ * The resulting map will not be of the specified size if there are duplicate keys returned by the factory.
+ */
+inline fun <T, U> makeMap(size: Int, factory: (Int) -> Pair<T, U>): MutableMap<T, U> =
+	mutableMapOf<T, U>().apply { repeat(size) { factory(it).let { (k, v) -> put(k, v) } } }
+
+/**
+ * Creates a mutable map of size [size], populating it by calling [factory] for each value.
+ * The resulting map will not be of the specified size if there are duplicate keys returned by the factory.
+ */
+inline fun <T, U> makeMap(size: UInt, factory: (Int) -> Pair<T, U>): MutableMap<T, U> =
+	mutableMapOf<T, U>().apply { repeat(size.toInt()) { factory(it).let { (k, v) -> put(k, v) } } }
+
+/**
+ * Creates a mutable map of size [size], populating it by calling [factory] for each value.
+ * The resulting map will not be of the specified size if there are duplicate keys returned by the factory.
+ * Variant that doesn't pass the index of current iteration to the factory.
+ * Named differently to avoid issues with overload resolution. KT-18451
+ */
+inline fun <T, U> makeMapN(size: Int, factory: () -> Pair<T, U>): MutableMap<T, U> =
+	mutableMapOf<T, U>().apply { repeat(size) { factory().let { (k, v) -> put(k, v) } } }
+
+/**
+ * Creates a mutable map of size [size], populating it by calling [factory] for each value.
+ * The resulting map will not be of the specified size if there are duplicate keys returned by the factory.
+ * Variant that doesn't pass the index of current iteration to the factory.
+ * Named differently to avoid issues with overload resolution. KT-18451
+ */
+inline fun <T, U> makeMapN(size: UInt, factory: () -> Pair<T, U>): MutableMap<T, U> =
+	mutableMapOf<T, U>().apply { repeat(size.toInt()) { factory().let { (k, v) -> put(k, v) } } }

--- a/commons/core/src/main/kotlin/org/elaastix/commons/KtUtils.kt
+++ b/commons/core/src/main/kotlin/org/elaastix/commons/KtUtils.kt
@@ -64,18 +64,6 @@ inline fun <T, R> Iterable<T>.mapSet(transform: (T) -> R): Set<R> {
 // SPDX-SnippetEnd
 
 /**
- * Creates a list of the specified [size] by calling the [factory].
- */
-inline fun <T> makeList(size: Int, factory: (Int) -> T): MutableList<T> =
-	mutableListOf<T>().apply { repeat(size) { add(factory(it)) } }
-
-/**
- * Creates a set of the specified [size] by calling the [factory].
- */
-inline fun <T> makeSet(size: Int, factory: (Int) -> T): MutableSet<T> =
-	mutableSetOf<T>().apply { repeat(size) { add(factory(it)) } }
-
-/**
  * Converts this instant to the ISO 8601 string representation, truncating sub-second information.
  *
  * @see Instant.toString

--- a/commons/spring/src/main/kotlin/org/elaastix/commons/TimeUtils.kt
+++ b/commons/spring/src/main/kotlin/org/elaastix/commons/TimeUtils.kt
@@ -1,0 +1,47 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.commons
+
+import org.springframework.scheduling.TaskScheduler
+import java.util.concurrent.ScheduledFuture
+import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.time.toJavaDuration
+import kotlin.time.toJavaInstant
+
+/** Kotlin-native extension of [TaskScheduler.schedule]. */
+fun TaskScheduler.schedule(task: Runnable, startTime: Instant): ScheduledFuture<*> =
+	schedule(task, startTime.toJavaInstant())
+
+/** Kotlin-native extension of [TaskScheduler.scheduleAtFixedRate]. */
+fun TaskScheduler.scheduleAtFixedRate(task: Runnable, startTime: Instant, period: Duration): ScheduledFuture<*> =
+	scheduleAtFixedRate(task, startTime.toJavaInstant(), period.toJavaDuration())
+
+/** Kotlin-native extension of [TaskScheduler.scheduleAtFixedRate]. */
+fun TaskScheduler.scheduleAtFixedRate(task: Runnable, period: Duration): ScheduledFuture<*> =
+	scheduleAtFixedRate(task, period.toJavaDuration())
+
+/** Kotlin-native extension of [TaskScheduler.scheduleWithFixedDelay]. */
+fun TaskScheduler.scheduleWithFixedDelay(task: Runnable, startTime: Instant, delay: Duration): ScheduledFuture<*> =
+	scheduleWithFixedDelay(task, startTime.toJavaInstant(), delay.toJavaDuration())
+
+/** Kotlin-native extension of [TaskScheduler.scheduleWithFixedDelay]. */
+fun TaskScheduler.scheduleWithFixedDelay(task: Runnable, delay: Duration): ScheduledFuture<*> =
+	scheduleWithFixedDelay(task, delay.toJavaDuration())

--- a/commons/spring/src/main/kotlin/org/elaastix/commons/jpa/entity/EntityListener.kt
+++ b/commons/spring/src/main/kotlin/org/elaastix/commons/jpa/entity/EntityListener.kt
@@ -23,10 +23,10 @@ import jakarta.persistence.PrePersist
 import org.elaastix.commons.platform.JpaImmutable
 import kotlin.time.Clock
 
-internal class EntityListener {
+internal class EntityListener(private val clock: Clock) {
 	@PrePersist
 	fun prePersist(entity: AbstractEntity) {
 		@OptIn(JpaImmutable::class)
-		entity.updatedAt = Clock.System.now()
+		entity.updatedAt = clock.now()
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ jdk = "25"
 kotlin = "2.3.21"
 ksp = "2.3.9"
 # ----
-assertj = "3.27.7"
 datafaker = "2.5.4"
 detekt = "2.0.0-alpha.3"
 flyway = "12.7.0"
@@ -21,7 +20,6 @@ springdoc-kdoc = "1.1.0"
 testcontainers = "2.0.5"
 
 [libraries]
-assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 datafaker = { module = "net.datafaker:datafaker", version.ref = "datafaker" }
 detekt-ktlint = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }
 flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }

--- a/server/src/main/kotlin/org/elaastix/server/OpenApiCommandLineRunner.kt
+++ b/server/src/main/kotlin/org/elaastix/server/OpenApiCommandLineRunner.kt
@@ -20,7 +20,7 @@
 package org.elaastix.server
 
 import io.swagger.v3.oas.models.OpenAPI
-import org.slf4j.LoggerFactory
+import org.apache.commons.logging.LogFactory
 import org.springdoc.webmvc.api.OpenApiResource
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.CommandLineRunner
@@ -51,7 +51,7 @@ class OpenApiCommandLineRunner(
 	private val openApiResource: OpenApiResource,
 ) : CommandLineRunner {
 	override fun run(vararg args: String) {
-		val logger = LoggerFactory.getLogger(this::class.java)
+		val logger = LogFactory.getLog(this::class.java)
 		logger.info("Generating OpenAPI specification. The server will exit once this is complete.")
 
 		val json = generate()

--- a/server/src/main/kotlin/org/elaastix/server/core/infrastructure/ExcludeFromSyntheticBoot.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/infrastructure/ExcludeFromSyntheticBoot.kt
@@ -17,20 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.elaastix.server.core.infrastructure.seed
+package org.elaastix.server.core.infrastructure
 
-import org.elaastix.server.core.infrastructure.ExcludeFromSyntheticBoot
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
-import org.springframework.context.annotation.Profile
-import org.springframework.stereotype.Component
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
 /**
- * Custom stereotype for database seeders.
+ * A "synthetic boot" occurs when the application starts exclusively to achieve a specific task and then shuts down.
+ * This annotation marks a component as excluded from these type of startups.
  */
-@Component
-@Profile("develop")
-@ExcludeFromSyntheticBoot
-@ConditionalOnMissingClass("testutils.WithMockUser")
-@Target(AnnotationTarget.CLASS)
+@ConditionalOnProperty("elaastix.synthetic-boot", havingValue = "false", matchIfMissing = true)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Seeder
+annotation class ExcludeFromSyntheticBoot

--- a/server/src/main/kotlin/org/elaastix/server/core/infrastructure/config/SchedulerConfig.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/infrastructure/config/SchedulerConfig.kt
@@ -1,0 +1,63 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.core.infrastructure.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import java.time.ZoneId
+import java.time.ZoneOffset
+import kotlin.time.Clock
+import kotlin.time.toJavaInstant
+import java.time.Clock as JClock
+import java.time.Instant as JInstant
+
+/**
+ * Configuration class providing beans required for task scheduling.
+ *
+ * Also provides an instance of [Clock] (and [JClock] for compatibility), to make time a dependency-injected resource.
+ * In tests, it is overridden with a controllable clock for easier testing of time-related events.
+ */
+@Configuration
+class SchedulerConfig {
+	@Bean
+	fun kClock(): Clock = Clock.System
+
+	@Bean
+	fun jClock(kClock: Clock): JClock =
+		object : JClock() {
+			override fun getZone() = ZoneOffset.UTC
+			override fun withZone(zone: ZoneId): JClock = ZonedClock(this, zone)
+			override fun instant() = kClock.now().toJavaInstant()
+		}
+
+	@Bean
+	fun scheduler() = ThreadPoolTaskScheduler()
+
+	private class ZonedClock(private val source: JClock, private val zone: ZoneId) : JClock() {
+		override fun getZone() = zone
+		override fun withZone(zone: ZoneId): JClock = ZonedClock(source, zone)
+		override fun instant(): JInstant = source.instant()
+
+		override fun equals(obj: Any?) = obj is ZonedClock && source == obj.source && zone == obj.zone
+		override fun hashCode() = source.hashCode() * 31 + zone.hashCode()
+		override fun toString() = "ZonedClock[$zone]"
+	}
+}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionRestoreRunner.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionRestoreRunner.kt
@@ -17,20 +17,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.elaastix.server.core.infrastructure.seed
+package org.elaastix.server.scenario.exec
 
+import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.core.infrastructure.ExcludeFromSyntheticBoot
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
-import org.springframework.context.annotation.Profile
+import org.springframework.boot.CommandLineRunner
 import org.springframework.stereotype.Component
 
 /**
- * Custom stereotype for database seeders.
+ * Service implementing the execution flow of the sequences.
+ * Caution: it assumes there is only one instance of the app ever running (which is going to be the case for now).
  */
 @Component
-@Profile("develop")
 @ExcludeFromSyntheticBoot
-@ConditionalOnMissingClass("testutils.WithMockUser")
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class Seeder
+@SciconumTechDebt
+class ScenarioExecutionRestoreRunner(private val executionService: ScenarioExecutionService) : CommandLineRunner {
+	override fun run(vararg args: String) {
+		executionService.restoreRunningSequences()
+	}
+}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionRestoreRunner.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionRestoreRunner.kt
@@ -33,6 +33,6 @@ import org.springframework.stereotype.Component
 @SciconumTechDebt
 class ScenarioExecutionRestoreRunner(private val executionService: ScenarioExecutionService) : CommandLineRunner {
 	override fun run(vararg args: String) {
-		executionService.restoreRunningSequences()
+		executionService.restoreRunningScenarioSessions()
 	}
 }

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionService.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionService.kt
@@ -56,10 +56,10 @@ class ScenarioExecutionService(
 	}
 
 	/**
-	 * Resumes execution of sessions, in case the server has been restarted or crashed.
+	 * Resumes execution of scenario sessions, in case the server has been restarted or crashed.
 	 */
 	@Transactional
-	fun restoreRunningSequences() {
+	fun restoreRunningScenarioSessions() {
 		val now = clock.now()
 		val ongoingSessions = sciconumScenarioSessionRepository.findAllByNextPhaseAtNotNull()
 		for (session in ongoingSessions) {
@@ -67,12 +67,15 @@ class ScenarioExecutionService(
 				when {
 					it < now -> {
 						val lag = (now - it).toInt(DurationUnit.SECONDS)
-						LOGGER.warn("Ticking session ${session.id}, was supposed to tick at $it ($lag seconds behind!)")
-						tickSession(session)
+						LOGGER.warn(
+							"Ticking scenario session ${session.id}, " +
+								"was supposed to tick at $it ($lag seconds behind!)",
+						)
+						tickScenarioSession(session)
 					}
 
 					else -> {
-						LOGGER.info("Resuming execution of session ${session.id}")
+						LOGGER.info("Resuming execution of scenario session ${session.id}")
 						taskScheduler.schedule(ExecutionTask(session.id), it)
 					}
 				}
@@ -81,19 +84,14 @@ class ScenarioExecutionService(
 	}
 
 	@Transactional
-	fun startSequenceById(sessionId: Uuid) {
-		val session = sciconumScenarioSessionRepository.findById(sessionId).orElseNotFound()
-		startSequence(session)
-	}
-
-	@Transactional
-	fun startSequence(session: SciconumScenarioSessionEntity) {
+	fun startSequenceScenarioSessionById(scenarioSessionId: Uuid) {
+		val session = sciconumScenarioSessionRepository.findById(scenarioSessionId).orElseNotFound()
 		check(session.phase == Phase.PENDING)
 		ExecutionTask(session.id).run()
 	}
 
 	@Suppress("CyclomaticComplexMethod") // The logic is just a big state machine
-	private fun tickSession(session: SciconumScenarioSessionEntity): Instant? {
+	private fun tickScenarioSession(session: SciconumScenarioSessionEntity): Instant? {
 		val currentPhase = session.phase
 		val scenario = session.sequence.sciconumScenario
 
@@ -117,12 +115,12 @@ class ScenarioExecutionService(
 
 		return when (currentPhase) {
 			Phase.PENDING ->
-				updateSession(session, Phase.QUESTION, constants.ANSWER_PHASE_DURATION)
+				updateScenarioSession(session, Phase.QUESTION, constants.ANSWER_PHASE_DURATION)
 
 			Phase.QUESTION ->
 				when (scenario) {
 					SciconumScenario.CONTROL ->
-						updateSession(session, Phase.FEEDBACK, constants.FEEDBACK_PHASE_DURATION)
+						updateScenarioSession(session, Phase.FEEDBACK, constants.FEEDBACK_PHASE_DURATION)
 
 					SciconumScenario.PEER_ASSESSMENT ->
 						startPeerAssessmentPhase(session)
@@ -132,18 +130,18 @@ class ScenarioExecutionService(
 				}
 
 			Phase.PEER ->
-				updateSession(session, Phase.REVISE, constants.REVISE_PHASE_DURATION)
+				updateScenarioSession(session, Phase.REVISE, constants.REVISE_PHASE_DURATION)
 
 			Phase.REVISE ->
-				updateSession(session, Phase.FEEDBACK, constants.FEEDBACK_PHASE_DURATION)
+				updateScenarioSession(session, Phase.FEEDBACK, constants.FEEDBACK_PHASE_DURATION)
 
 			Phase.FEEDBACK -> {
 				when (++session.currentRound) {
 					session.sequence.sciconumQuestions.size.toUInt() ->
-						updateSession(session, Phase.END, null)
+						updateScenarioSession(session, Phase.END, null)
 
 					else ->
-						updateSession(session, Phase.QUESTION, constants.ANSWER_PHASE_DURATION)
+						updateScenarioSession(session, Phase.QUESTION, constants.ANSWER_PHASE_DURATION)
 				}
 			}
 
@@ -153,15 +151,19 @@ class ScenarioExecutionService(
 
 	private fun startPeerAssessmentPhase(session: SciconumScenarioSessionEntity): Instant? {
 		// TODO: Assign answers
-		return updateSession(session, Phase.PEER, Assessment.PEER_PHASE_DURATION)
+		return updateScenarioSession(session, Phase.PEER, Assessment.PEER_PHASE_DURATION)
 	}
 
 	private fun startPeerDebatePhase(session: SciconumScenarioSessionEntity): Instant? {
 		// TODO: Assign peers
-		return updateSession(session, Phase.PEER, Debate.PEER_PHASE_DURATION)
+		return updateScenarioSession(session, Phase.PEER, Debate.PEER_PHASE_DURATION)
 	}
 
-	private fun updateSession(session: SciconumScenarioSessionEntity, phase: Phase, nextTickIn: Duration?): Instant? {
+	private fun updateScenarioSession(
+		session: SciconumScenarioSessionEntity,
+		phase: Phase,
+		nextTickIn: Duration?,
+	): Instant? {
 		val nextTick = nextTickIn?.let { clock.now().plus(nextTickIn) }
 		LOGGER.trace("Transitioning session ${session.id} (${session.phase} -> $phase)")
 
@@ -172,16 +174,16 @@ class ScenarioExecutionService(
 		return nextTick
 	}
 
-	private inner class ExecutionTask(private val sessionId: Uuid) : Runnable {
+	private inner class ExecutionTask(private val scenarioSessionId: Uuid) : Runnable {
 		override fun run() {
 			transactionTemplate.execute {
-				val session = checkNotNull(sciconumScenarioSessionRepository.findByIdOrNull(sessionId))
-				tickSession(session)
+				val session = checkNotNull(sciconumScenarioSessionRepository.findByIdOrNull(scenarioSessionId))
+				tickScenarioSession(session)
 			}?.let {
 				if (LOGGER.isDebugEnabled) {
 					val now = clock.now()
 					val delta = (it - now).toInt(DurationUnit.SECONDS)
-					LOGGER.debug("Scheduling next tick of session $sessionId at $it (in $delta seconds)")
+					LOGGER.debug("Scheduling next tick of session $scenarioSessionId at $it (in $delta seconds)")
 				}
 				taskScheduler.schedule(this, it)
 			}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionService.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionService.kt
@@ -28,8 +28,6 @@ import org.elaastix.server.scenario.SciconumScenario
 import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
 import org.elaastix.server.scenario.exec.repositories.SciconumLearnerSessionRepository
 import org.elaastix.server.scenario.exec.repositories.SciconumScenarioSessionRepository
-import org.springframework.boot.context.event.ApplicationStartedEvent
-import org.springframework.context.event.EventListener
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -58,13 +56,13 @@ class ScenarioExecutionService(
 	}
 
 	/**
-	 * Handler resuming execution of sessions in case the server has been restarted or crashed.
+	 * Resumes execution of sessions, in case the server has been restarted or crashed.
 	 */
 	@Transactional
-	@EventListener(ApplicationStartedEvent::class)
 	fun restoreRunningSequences() {
 		val now = clock.now()
-		for (session in sciconumScenarioSessionRepository.findAllByNextPhaseAtNotNull()) {
+		val ongoingSessions = sciconumScenarioSessionRepository.findAllByNextPhaseAtNotNull()
+		for (session in ongoingSessions) {
 			session.nextPhaseAt?.let {
 				when {
 					it < now -> {

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionService.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionService.kt
@@ -1,0 +1,192 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec
+
+import org.apache.commons.logging.LogFactory
+import org.elaastix.commons.data.Uuid
+import org.elaastix.commons.orElseNotFound
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.commons.schedule
+import org.elaastix.server.scenario.SciconumScenario
+import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
+import org.elaastix.server.scenario.exec.repositories.SciconumLearnerSessionRepository
+import org.elaastix.server.scenario.exec.repositories.SciconumScenarioSessionRepository
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.Instant
+import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase as Phase
+
+/**
+ * Service implementing the execution flow of the sequences.
+ * Caution: it assumes there is only one instance of the app ever running (which is going to be the case for now).
+ */
+@Service
+@SciconumTechDebt
+class ScenarioExecutionService(
+	private val taskScheduler: TaskScheduler,
+	private val transactionTemplate: TransactionTemplate,
+	private val sciconumScenarioSessionRepository: SciconumScenarioSessionRepository,
+	private val sciconumLearnerSessionRepository: SciconumLearnerSessionRepository,
+	private val clock: Clock,
+) {
+	companion object {
+		private val LOGGER = LogFactory.getLog(ScenarioExecutionService::class.java)
+	}
+
+	/**
+	 * Handler resuming execution of sessions in case the server has been restarted or crashed.
+	 */
+	@Transactional
+	@EventListener(ApplicationStartedEvent::class)
+	fun restoreRunningSequences() {
+		val now = clock.now()
+		for (session in sciconumScenarioSessionRepository.findAllByNextPhaseAtNotNull()) {
+			session.nextPhaseAt?.let {
+				when {
+					it < now -> {
+						val lag = (now - it).toInt(DurationUnit.SECONDS)
+						LOGGER.warn("Ticking session ${session.id}, was supposed to tick at $it ($lag seconds behind!)")
+						tickSession(session)
+					}
+
+					else -> {
+						LOGGER.info("Resuming execution of session ${session.id}")
+						taskScheduler.schedule(ExecutionTask(session.id), it)
+					}
+				}
+			}
+		}
+	}
+
+	@Transactional
+	fun startSequenceById(sessionId: Uuid) {
+		val session = sciconumScenarioSessionRepository.findById(sessionId).orElseNotFound()
+		startSequence(session)
+	}
+
+	@Transactional
+	fun startSequence(session: SciconumScenarioSessionEntity) {
+		check(session.phase == Phase.PENDING)
+		ExecutionTask(session.id).run()
+	}
+
+	@Suppress("CyclomaticComplexMethod") // The logic is just a big state machine
+	private fun tickSession(session: SciconumScenarioSessionEntity): Instant? {
+		val currentPhase = session.phase
+		val scenario = session.sequence.sciconumScenario
+
+		if (LOGGER.isDebugEnabled) {
+			val now = clock.now()
+			val delta = session.nextPhaseAt?.let { (now - it).toInt(DurationUnit.SECONDS) } ?: 0
+			LOGGER.debug(
+				"Ticking session ${session.id} (" +
+					"Scenario: $scenario; " +
+					"Current phase: $currentPhase; " +
+					"Round: ${session.currentRound}; " +
+					"Tick delay: $delta seconds)",
+			)
+		}
+
+		val constants = when (scenario) {
+			SciconumScenario.CONTROL -> Control
+			SciconumScenario.PEER_ASSESSMENT -> Assessment
+			SciconumScenario.PEER_DEBATE -> Debate
+		}
+
+		return when (currentPhase) {
+			Phase.PENDING ->
+				updateSession(session, Phase.QUESTION, constants.ANSWER_PHASE_DURATION)
+
+			Phase.QUESTION ->
+				when (scenario) {
+					SciconumScenario.CONTROL ->
+						updateSession(session, Phase.FEEDBACK, constants.FEEDBACK_PHASE_DURATION)
+
+					SciconumScenario.PEER_ASSESSMENT ->
+						startPeerAssessmentPhase(session)
+
+					SciconumScenario.PEER_DEBATE ->
+						startPeerDebatePhase(session)
+				}
+
+			Phase.PEER ->
+				updateSession(session, Phase.REVISE, constants.REVISE_PHASE_DURATION)
+
+			Phase.REVISE ->
+				updateSession(session, Phase.FEEDBACK, constants.FEEDBACK_PHASE_DURATION)
+
+			Phase.FEEDBACK -> {
+				when (++session.currentRound) {
+					session.sequence.sciconumQuestions.size.toUInt() ->
+						updateSession(session, Phase.END, null)
+
+					else ->
+						updateSession(session, Phase.QUESTION, constants.ANSWER_PHASE_DURATION)
+				}
+			}
+
+			Phase.END -> error("Ticking an ended session?!")
+		}
+	}
+
+	private fun startPeerAssessmentPhase(session: SciconumScenarioSessionEntity): Instant? {
+		// TODO: Assign answers
+		return updateSession(session, Phase.PEER, Assessment.PEER_PHASE_DURATION)
+	}
+
+	private fun startPeerDebatePhase(session: SciconumScenarioSessionEntity): Instant? {
+		// TODO: Assign peers
+		return updateSession(session, Phase.PEER, Debate.PEER_PHASE_DURATION)
+	}
+
+	private fun updateSession(session: SciconumScenarioSessionEntity, phase: Phase, nextTickIn: Duration?): Instant? {
+		val nextTick = nextTickIn?.let { clock.now().plus(nextTickIn) }
+		LOGGER.trace("Transitioning session ${session.id} (${session.phase} -> $phase)")
+
+		session.phase = phase
+		session.nextPhaseAt = nextTick
+		sciconumLearnerSessionRepository.transitionAllLearnerSessionsOfSessionTo(session, phase, nextTick)
+
+		return nextTick
+	}
+
+	private inner class ExecutionTask(private val sessionId: Uuid) : Runnable {
+		override fun run() {
+			transactionTemplate.execute {
+				val session = checkNotNull(sciconumScenarioSessionRepository.findByIdOrNull(sessionId))
+				tickSession(session)
+			}?.let {
+				if (LOGGER.isDebugEnabled) {
+					val now = clock.now()
+					val delta = (it - now).toInt(DurationUnit.SECONDS)
+					LOGGER.debug("Scheduling next tick of session $sessionId at $it (in $delta seconds)")
+				}
+				taskScheduler.schedule(this, it)
+			}
+		}
+	}
+}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/SciconumConstants.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/SciconumConstants.kt
@@ -1,0 +1,58 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("VariableNaming", "PropertyName")
+
+package org.elaastix.server.scenario.exec
+
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+@SciconumTechDebt
+interface ScenarioConstants {
+	val ANSWER_PHASE_DURATION: Duration
+	val PEER_PHASE_DURATION: Duration
+	val REVISE_PHASE_DURATION: Duration
+	val FEEDBACK_PHASE_DURATION: Duration
+}
+
+@SciconumTechDebt
+object Control : ScenarioConstants {
+	override val ANSWER_PHASE_DURATION = 2.minutes
+	override val PEER_PHASE_DURATION get() = error("Peer phase is not a thing in control!!")
+	override val REVISE_PHASE_DURATION get() = error("Revise phase is not a thing in control!!")
+	override val FEEDBACK_PHASE_DURATION = 0.5.minutes
+}
+
+@SciconumTechDebt
+object Assessment : ScenarioConstants {
+	override val ANSWER_PHASE_DURATION = 2.minutes
+	override val PEER_PHASE_DURATION = 3.5.minutes
+	override val REVISE_PHASE_DURATION = 0.5.minutes
+	override val FEEDBACK_PHASE_DURATION = 1.5.minutes
+}
+
+@SciconumTechDebt
+object Debate : ScenarioConstants {
+	override val ANSWER_PHASE_DURATION = 1.minutes
+	override val PEER_PHASE_DURATION = 5.5.minutes
+	override val REVISE_PHASE_DURATION = 0.5.minutes
+	override val FEEDBACK_PHASE_DURATION = 0.5.minutes
+}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/SciconumScenarioSessionCreator.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/SciconumScenarioSessionCreator.kt
@@ -26,6 +26,7 @@ import org.elaastix.server.scenario.exec.entities.SciconumLearnerSessionEntity
 import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
 import org.elaastix.server.scenario.exec.repositories.SciconumLearnerSessionRepository
 import org.elaastix.server.scenario.exec.repositories.SciconumScenarioSessionRepository
+import org.elaastix.server.sequences.SciconumSequenceEntity
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -59,7 +60,7 @@ class SciconumScenarioSessionCreator(
 
 	@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
 	fun handleAssignmentCreation(event: AssignmentCreateEvent) {
-		val sequences = event.assignment.sequences
+		val sequences = event.assignment.sequences.filterIsInstance<SciconumSequenceEntity>()
 		check(sequences.isNotEmpty())
 
 		for (sequence in sequences) {

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/entities/SciconumScenarioSessionEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/entities/SciconumScenarioSessionEntity.kt
@@ -30,7 +30,7 @@ import org.elaastix.commons.jpa.entity.AbstractEntity
 import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.assignments.AssignmentEntity
 import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase
-import org.elaastix.server.sequences.SequenceEntity
+import org.elaastix.server.sequences.SciconumSequenceEntity
 import kotlin.time.Instant
 
 @Entity
@@ -48,7 +48,7 @@ class SciconumScenarioSessionEntity(
 
 	@NotNull
 	@ManyToOne
-	var sequence: SequenceEntity,
+	var sequence: SciconumSequenceEntity,
 
 	// -- State data
 

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/repositories/SciconumLearnerSessionRepository.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/repositories/SciconumLearnerSessionRepository.kt
@@ -22,25 +22,42 @@ package org.elaastix.server.scenario.exec.repositories
 import org.elaastix.commons.jpa.repository.ElaastixRepository
 import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.assignments.AssignmentEntity
+import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase
 import org.elaastix.server.scenario.exec.entities.SciconumLearnerSessionEntity
 import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
 import org.elaastix.server.users.entities.UserEntity
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import kotlin.time.Instant
 
 @Repository
 @SciconumTechDebt
 interface SciconumLearnerSessionRepository : ElaastixRepository<SciconumLearnerSessionEntity> {
 	@Query(
-		"FROM SciconumLearnerSessionEntity sls WHERE sls.learner = :learner AND sls.scenarioSession.assignment = :assignment",
+		"FROM SciconumLearnerSessionEntity sls " +
+			"WHERE sls.learner = :learner AND sls.scenarioSession.assignment = :assignment",
 	)
 	fun findAllByAssignmentAndLearner(
 		assignment: AssignmentEntity,
 		learner: UserEntity,
 	): List<SciconumLearnerSessionEntity>
 
-	fun findAllByScenarioSessionAndLearner(
+	fun findOneByScenarioSessionAndLearner(
 		globalSession: SciconumScenarioSessionEntity,
 		learner: UserEntity,
-	): List<SciconumLearnerSessionEntity>
+	): SciconumLearnerSessionEntity?
+
+	fun findAllByScenarioSession(globalSession: SciconumScenarioSessionEntity): List<SciconumLearnerSessionEntity>
+
+	@Modifying
+	@Query(
+		"UPDATE SciconumLearnerSessionEntity sls SET sls.phase = :phase, sls.nextPhaseAt = :nextPhaseAt " +
+			"WHERE sls.scenarioSession = :scenarioSession AND (:phase = 'QUESTION' OR sls.phase != 'PENDING')",
+	)
+	fun transitionAllLearnerSessionsOfSessionTo(
+		scenarioSession: SciconumScenarioSessionEntity,
+		phase: SciconumScenarioExecutionPhase,
+		nextPhaseAt: Instant?,
+	): Int
 }

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/repositories/SciconumScenarioSessionRepository.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/repositories/SciconumScenarioSessionRepository.kt
@@ -23,7 +23,7 @@ import org.elaastix.commons.jpa.repository.ElaastixRepository
 import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.assignments.AssignmentEntity
 import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
-import org.elaastix.server.sequences.SequenceEntity
+import org.elaastix.server.sequences.SciconumSequenceEntity
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -31,8 +31,10 @@ import org.springframework.stereotype.Repository
 interface SciconumScenarioSessionRepository : ElaastixRepository<SciconumScenarioSessionEntity> {
 	fun findAllByAssignment(assignment: AssignmentEntity): List<SciconumScenarioSessionEntity>
 
+	fun findAllByNextPhaseAtNotNull(): List<SciconumScenarioSessionEntity>
+
 	fun findOneByAssignmentAndSequence(
 		assignment: AssignmentEntity,
-		sequenceEntity: SequenceEntity,
+		sequenceEntity: SciconumSequenceEntity,
 	): SciconumScenarioSessionEntity?
 }

--- a/server/src/main/resources/application-develop.yaml
+++ b/server/src/main/resources/application-develop.yaml
@@ -1,4 +1,9 @@
 debug: true
+logging.level:
+  org.elaastix: DEBUG
+  # For SQL parameters, if needed
+  #org.hibernate.orm.jdbc.bind: TRACE
+
 spring:
   datasource:
     url: jdbc:postgresql://127.0.0.1:5432/elaastix

--- a/server/src/main/resources/application-openapi.yaml
+++ b/server/src/main/resources/application-openapi.yaml
@@ -7,3 +7,5 @@ logging.level.root: WARN
 logging.level.org.elaastix.server: INFO
 
 generation-path: build/openapi.json
+
+elaastix.synthetic-boot: true

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/SciconumIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/SciconumIntegrationTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec
+
+import org.elaastix.commons.makeList
+import org.elaastix.commons.makeSet
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.mm.content.PlainText
+import org.elaastix.server.activities.response.ClosedAnswer
+import org.elaastix.server.activities.response.entities.ClosedQuestionEntity
+import org.elaastix.server.activities.response.repositories.QuestionRepository
+import org.elaastix.server.assignments.AssignmentEntity
+import org.elaastix.server.assignments.AssignmentRepository
+import org.elaastix.server.assignments.AssignmentService
+import org.elaastix.server.assignments.dto.CreateAssignmentDto
+import org.elaastix.server.assignments.participants.AssignmentParticipantsService
+import org.elaastix.server.scenario.SciconumScenario
+import org.elaastix.server.scenario.exec.repositories.SciconumLearnerSessionRepository
+import org.elaastix.server.scenario.exec.repositories.SciconumScenarioSessionRepository
+import org.elaastix.server.sequences.SciconumSequenceEntity
+import org.elaastix.server.sequences.SequenceEntity
+import org.elaastix.server.sequences.SequenceRepository
+import org.elaastix.server.users.UserRepository
+import org.elaastix.server.users.entities.UserEntity
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import testutils.ControllableClock
+import testutils.IntegrationTest
+import testutils.WithMockUser
+import testutils.email
+
+@WithMockUser
+@SpringBootTest
+@OptIn(SciconumTechDebt::class)
+abstract class SciconumIntegrationTest : IntegrationTest() {
+	@Autowired
+	lateinit var clock: ControllableClock
+
+	@Autowired
+	lateinit var userRepository: UserRepository
+
+	@Autowired
+	lateinit var questionRepository: QuestionRepository
+
+	@Autowired
+	lateinit var sequenceRepository: SequenceRepository
+
+	@Autowired
+	lateinit var assignmentRepository: AssignmentRepository
+
+	@Autowired
+	lateinit var sciconumScenarioSessionRepository: SciconumScenarioSessionRepository
+
+	@Autowired
+	lateinit var sciconumLearnerSessionRepository: SciconumLearnerSessionRepository
+
+	@Autowired
+	lateinit var assignmentService: AssignmentService
+
+	@Autowired
+	lateinit var assignmentParticipantsService: AssignmentParticipantsService
+
+	fun createAssignment(
+		sequencesCount: UInt,
+		scenario: SciconumScenario,
+		questionsPerSequence: UInt,
+	): AssignmentEntity =
+		assignmentRepository.findById(
+			assignmentService.createAssignment(
+				CreateAssignmentDto(
+					displayName = makeRecognisableName(),
+					sequenceIds = makeList(sequencesCount.toInt()) {
+						createSequence(scenario, questionsPerSequence).id
+					},
+				)
+			).id
+		).orElseThrow()
+
+	fun createSequence(scenario: SciconumScenario, questionsCount: UInt): SequenceEntity =
+		sequenceRepository.persist(
+			SciconumSequenceEntity(
+				name = makeRecognisableName(),
+				sciconumScenario = scenario,
+				sciconumQuestions = makeSet(questionsCount.toInt()) {
+					questionRepository.persist(
+						ClosedQuestionEntity(
+							statement = PlainText(FAKER.lorem().sentence(10)),
+							choices = makeList(4) { PlainText(FAKER.lorem().sentence(3)) },
+							expectedAnswer = ClosedAnswer.Single(1u),
+							answerExplanation = null,
+							multiple = false,
+						),
+					)
+				},
+			),
+		)
+
+	fun createUser(): UserEntity =
+		userRepository.persist(
+			UserEntity(
+				firstName = FAKER.name().firstName(),
+				lastName = FAKER.name().lastName(),
+				email = FAKER.email(),
+			),
+		)
+}

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/SciconumIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/SciconumIntegrationTest.kt
@@ -89,8 +89,8 @@ abstract class SciconumIntegrationTest : IntegrationTest() {
 					sequenceIds = makeList(sequencesCount) {
 						createSequence(scenario, questionsPerSequence).id
 					},
-				)
-			).id
+				),
+			).id,
 		).orElseThrow()
 
 	fun createSequence(scenario: SciconumScenario, questionsCount: UInt): SequenceEntity =

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/SciconumIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/SciconumIntegrationTest.kt
@@ -86,7 +86,7 @@ abstract class SciconumIntegrationTest : IntegrationTest() {
 			assignmentService.createAssignment(
 				CreateAssignmentDto(
 					displayName = makeRecognisableName(),
-					sequenceIds = makeList(sequencesCount.toInt()) {
+					sequenceIds = makeList(sequencesCount) {
 						createSequence(scenario, questionsPerSequence).id
 					},
 				)

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/SciconumSessionCreationIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/SciconumSessionCreationIntegrationTest.kt
@@ -21,91 +21,25 @@ package org.elaastix.server.scenario.exec
 
 import org.assertj.core.api.Assertions.assertThat
 import org.elaastix.commons.makeList
-import org.elaastix.commons.makeSet
 import org.elaastix.commons.platform.debt.SciconumTechDebt
-import org.elaastix.mm.content.PlainText
-import org.elaastix.server.activities.response.ClosedAnswer
-import org.elaastix.server.activities.response.entities.ClosedQuestionEntity
-import org.elaastix.server.activities.response.repositories.QuestionRepository
-import org.elaastix.server.assignments.AssignmentRepository
-import org.elaastix.server.assignments.AssignmentService
-import org.elaastix.server.assignments.dto.AssignmentDto
 import org.elaastix.server.assignments.dto.CreateAssignmentDto
-import org.elaastix.server.assignments.participants.AssignmentParticipantsService
 import org.elaastix.server.scenario.SciconumScenario
-import org.elaastix.server.scenario.exec.repositories.SciconumLearnerSessionRepository
-import org.elaastix.server.scenario.exec.repositories.SciconumScenarioSessionRepository
-import org.elaastix.server.sequences.SciconumSequenceEntity
-import org.elaastix.server.sequences.SequenceRepository
-import org.elaastix.server.users.UserRepository
-import org.elaastix.server.users.entities.UserEntity
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import testutils.IntegrationTest
-import testutils.WithMockUser
-import testutils.email
 
-@WithMockUser
 @SpringBootTest
 @OptIn(SciconumTechDebt::class)
-class SciconumSessionCreationIntegrationTest : IntegrationTest() {
-	@Autowired
-	lateinit var userRepository: UserRepository
+class SciconumSessionCreationIntegrationTest : SciconumIntegrationTest() {
+	@Test
+	fun `creating an assignment creates a session for each sequence`() {
+		val sequences = makeList(3) { createSequence(SciconumScenario.CONTROL, 1u) }
 
-	@Autowired
-	lateinit var questionRepository: QuestionRepository
-
-	@Autowired
-	lateinit var sequenceRepository: SequenceRepository
-
-	@Autowired
-	lateinit var assignmentRepository: AssignmentRepository
-
-	@Autowired
-	lateinit var sciconumScenarioSessionRepository: SciconumScenarioSessionRepository
-
-	@Autowired
-	lateinit var sciconumLearnerSessionRepository: SciconumLearnerSessionRepository
-
-	@Autowired
-	lateinit var assignmentService: AssignmentService
-
-	@Autowired
-	lateinit var assignmentParticipantsService: AssignmentParticipantsService
-
-	private fun createAssignment(): AssignmentDto {
-		val sequences = makeList(3) {
-			sequenceRepository.persist(
-				SciconumSequenceEntity(
-					name = makeRecognisableName(),
-					sciconumScenario = SciconumScenario.CONTROL,
-					sciconumQuestions = makeSet(1) {
-						questionRepository.persist(
-							ClosedQuestionEntity(
-								statement = PlainText(FAKER.lorem().sentence(10)),
-								choices = makeList(4) { PlainText(FAKER.lorem().sentence(3)) },
-								expectedAnswer = ClosedAnswer.Single(1u),
-								answerExplanation = null,
-								multiple = false,
-							),
-						)
-					},
-				),
-			)
-		}
-
-		return assignmentService.createAssignment(
+		val assignmentDto = assignmentService.createAssignment(
 			CreateAssignmentDto(
 				displayName = makeRecognisableName(),
 				sequenceIds = sequences.map { it.id },
 			),
 		)
-	}
-
-	@Test
-	fun `creating an assignment creates a session for each sequence`() {
-		val assignmentDto = createAssignment()
 
 		// -- then
 
@@ -116,14 +50,8 @@ class SciconumSessionCreationIntegrationTest : IntegrationTest() {
 
 	@Test
 	fun `adding a learner to an assignment creates a learner session for each sequence`() {
-		val assignment = assignmentRepository.findById(createAssignment().id).orElseThrow()
-		val user = userRepository.persist(
-			UserEntity(
-				firstName = FAKER.name().firstName(),
-				lastName = FAKER.name().lastName(),
-				email = FAKER.email(),
-			),
-		)
+		val assignment = createAssignment(3u, SciconumScenario.CONTROL, 1u)
+		val user = createUser()
 
 		assignmentParticipantsService.addParticipantToAssignmentById(assignment.id, user.id)
 
@@ -135,18 +63,13 @@ class SciconumSessionCreationIntegrationTest : IntegrationTest() {
 
 	@Test
 	fun `adding a learner to an assignment does not create a session for ended sequences`() {
-		val assignment = assignmentRepository.findById(createAssignment().id).orElseThrow()
-		val session = sciconumScenarioSessionRepository.findAllByAssignment(assignment).first()
-		session.phase = SciconumScenarioExecutionPhase.END
-		sciconumScenarioSessionRepository.update(session)
+		val assignment = createAssignment(3u, SciconumScenario.CONTROL, 1u)
+		val user = createUser()
 
-		val user = userRepository.persist(
-			UserEntity(
-				firstName = FAKER.name().firstName(),
-				lastName = FAKER.name().lastName(),
-				email = FAKER.email(),
-			),
-		)
+		tx.execute {
+			val session = sciconumScenarioSessionRepository.findAllByAssignment(assignment).first()
+			session.phase = SciconumScenarioExecutionPhase.END
+		}
 
 		assignmentParticipantsService.addParticipantToAssignmentById(assignment.id, user.id)
 

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/AbstractSciconumFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/AbstractSciconumFlowTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec.flow
+
+import org.elaastix.commons.jpa.entity.AbstractEntity
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.server.assignments.AssignmentEntity
+import org.elaastix.server.scenario.SciconumScenario
+import org.elaastix.server.scenario.exec.ScenarioExecutionService
+import org.elaastix.server.scenario.exec.SciconumIntegrationTest
+import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.time.Duration
+
+@SpringBootTest
+@OptIn(SciconumTechDebt::class)
+abstract class AbstractSciconumFlowTest : SciconumIntegrationTest() {
+	@Autowired
+	lateinit var sciconumScenarioExecutionService: ScenarioExecutionService
+
+	fun validateScenario(scenario: SciconumScenario, questionsCount: UInt, block: TimedFlowDsl.() -> Unit) {
+		val assignment = createAssignment(1u, scenario, questionsCount)
+		val session = sciconumScenarioSessionRepository.findAllByAssignment(assignment).single()
+
+		TimedFlowDsl(assignment, session).apply(block)
+	}
+
+	inner class TimedFlowDsl(
+		/**
+		 * The assignment created for the test.
+		 */
+		val assignment: AssignmentEntity,
+
+		/**
+		 * The global session created for the test.
+		 */
+		val scenarioSession: SciconumScenarioSessionEntity,
+	) {
+		/**
+		 * Creates a learner and adds them to the assignment.
+		 *
+		 * ```kt
+		 * validateScenario(SciconumScenario.CONTROL, 9u) {
+		 *     val (learner1, session1) = createLearner()
+		 *     val (learner2, session2) = createLearner()
+		 * }
+		 * ```
+		 */
+		fun createLearner() =
+			createUser()
+				.also { assignmentParticipantsService.addParticipantToAssignmentById(assignment.id, it.id) }
+				.let {
+					val sess = sciconumLearnerSessionRepository.findOneByScenarioSessionAndLearner(scenarioSession, it)
+					it to checkNotNull(sess)
+				}
+
+		/**
+		 * Starts the execution of the test scenario.
+		 */
+		fun start() = sciconumScenarioExecutionService.startSequence(scenarioSession)
+
+		/**
+		 * Advances the clock by [duration].
+		 *
+		 * ```kt
+		 * validateScenario(SciconumScenario.CONTROL, 9u) {
+		 *     val (learner1, session1) by creatingLearner
+		 *
+		 *     advanceClock(1.minutes)
+		 *
+		 *     session1 satisfies { id == ... }
+		 * }
+		 * ```
+		 */
+		fun advanceClock(duration: Duration) = clock.add(duration)
+
+		private typealias E = AbstractEntity
+
+		private fun <T : E> T.refresh0(): T = em.find(this::class.java, id)
+
+		@JvmName("refresh1")
+		fun <T : E> T.refresh(): T =
+			tx.execute { refresh0() }
+
+		fun <T : E> refresh(e1: T): T =
+			tx.execute { e1.refresh0() }
+
+		fun <T : E, U : E> refresh(e1: T, e2: U): Pair<T, U> =
+			tx.execute { Pair(e1.refresh0(), e2.refresh0()) }
+
+		fun <T : E, U : E, V : E> refresh(e1: T, e2: U, e3: V): Triple<T, U, V> =
+			tx.execute { Triple(e1.refresh0(), e2.refresh0(), e3.refresh0()) }
+
+		fun <T : E, U : E, V : E, W : E> refresh(e1: T, e2: U, e3: V, e4: W): Quadruple<T, U, V, W> =
+			tx.execute { Quadruple(e1.refresh0(), e2.refresh0(), e3.refresh0(), e4.refresh0()) }
+	}
+
+	data class Quadruple<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
+}

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/AbstractSciconumFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/AbstractSciconumFlowTest.kt
@@ -19,16 +19,19 @@
 
 package org.elaastix.server.scenario.exec.flow
 
-import org.elaastix.commons.jpa.entity.AbstractEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.elaastix.commons.makeMapN
 import org.elaastix.commons.platform.debt.SciconumTechDebt
-import org.elaastix.server.assignments.AssignmentEntity
 import org.elaastix.server.scenario.SciconumScenario
 import org.elaastix.server.scenario.exec.ScenarioExecutionService
 import org.elaastix.server.scenario.exec.SciconumIntegrationTest
-import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
+import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase
+import org.elaastix.server.scenario.exec.entities.SciconumLearnerSessionEntity
+import org.elaastix.server.users.entities.UserEntity
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 
 @SpringBootTest
 @OptIn(SciconumTechDebt::class)
@@ -36,31 +39,32 @@ abstract class AbstractSciconumFlowTest : SciconumIntegrationTest() {
 	@Autowired
 	lateinit var sciconumScenarioExecutionService: ScenarioExecutionService
 
-	fun validateScenario(scenario: SciconumScenario, questionsCount: UInt, block: TimedFlowDsl.() -> Unit) {
-		val assignment = createAssignment(1u, scenario, questionsCount)
-		val session = sciconumScenarioSessionRepository.findAllByAssignment(assignment).single()
-
-		TimedFlowDsl(assignment, session).apply(block)
+	fun validateScenario(
+		scenario: SciconumScenario,
+		questionsCount: UInt,
+		initialLearnersCount: UInt,
+		block: TimedFlowDsl.() -> Unit,
+	) {
+		TimedFlowDsl(scenario, questionsCount, initialLearnersCount).apply(block)
 	}
 
-	inner class TimedFlowDsl(
-		/**
-		 * The assignment created for the test.
-		 */
-		val assignment: AssignmentEntity,
+	inner class TimedFlowDsl(scenario: SciconumScenario, questionsCount: UInt, initialLearnersCount: UInt) {
+		/** The assignment created for the test. */
+		val assignment = createAssignment(1u, scenario, questionsCount)
 
-		/**
-		 * The global session created for the test.
-		 */
-		val scenarioSession: SciconumScenarioSessionEntity,
-	) {
+		/** The global session created for the test. */
+		val scenarioSession = sciconumScenarioSessionRepository.findAllByAssignment(assignment).single()
+
+		/** Initial learners (and their session) created for the test. */
+		val learners: Map<UserEntity, SciconumLearnerSessionEntity> = makeMapN(initialLearnersCount, ::createLearner)
+
 		/**
 		 * Creates a learner and adds them to the assignment.
 		 *
 		 * ```kt
 		 * validateScenario(SciconumScenario.CONTROL, 9u) {
-		 *     val (learner1, session1) = createLearner()
-		 *     val (learner2, session2) = createLearner()
+		 *     val (learner, learnerSession) = createLearner()
+		 *     ...
 		 * }
 		 * ```
 		 */
@@ -92,26 +96,115 @@ abstract class AbstractSciconumFlowTest : SciconumIntegrationTest() {
 		 */
 		fun advanceClock(duration: Duration) = clock.add(duration)
 
-		private typealias E = AbstractEntity
+		/**
+		 * Checks that the session will transition to [phase] after exactly the duration set in [after].
+		 * Can optionally take any number of session to check. Internally, this function uses [assertThatAllSessions].
+		 *
+		 * This will assert that the state does not change after `duration - 1ns`, but does so after `duration`.
+		 */
+		fun checkTransitionToPhaseAfter(
+			phase: SciconumScenarioExecutionPhase,
+			after: Duration,
+			vararg sessions: SciconumLearnerSessionEntity,
+		) {
+			advanceClock(after - 1.nanoseconds)
+			assertThatAllSessions(*sessions).areNotInPhase(phase)
 
-		private fun <T : E> T.refresh0(): T = em.find(this::class.java, id)
+			advanceClock(1.nanoseconds)
+			assertThatAllSessions(*sessions).areInPhase(phase)
+		}
 
-		@JvmName("refresh1")
-		fun <T : E> T.refresh(): T =
-			tx.execute { refresh0() }
+		/**
+		 * Prepares an assertion object with the sessions passed in arguments.
+		 */
+		fun assertThatSpecificSessions(vararg sessions: SciconumLearnerSessionEntity) =
+			SessionsAssert(sessions)
 
-		fun <T : E> refresh(e1: T): T =
-			tx.execute { e1.refresh0() }
+		/**
+		 * Prepares an assertion object with the sessions passed in arguments.
+		 */
+		fun assertThatSpecificSession(session: SciconumLearnerSessionEntity) =
+			SessionAssert(session)
 
-		fun <T : E, U : E> refresh(e1: T, e2: U): Pair<T, U> =
-			tx.execute { Pair(e1.refresh0(), e2.refresh0()) }
+		/**
+		 * Prepares an assertion object with the global session, initial learner session, as well as sessions
+		 * passed in arguments.
+		 *
+		 * Initially created sessions **must not** be passed to this function.
+		 */
+		fun assertThatAllSessions(vararg sessions: SciconumLearnerSessionEntity) =
+			AllSessionsAssert(sessions)
 
-		fun <T : E, U : E, V : E> refresh(e1: T, e2: U, e3: V): Triple<T, U, V> =
-			tx.execute { Triple(e1.refresh0(), e2.refresh0(), e3.refresh0()) }
+		/** Assertions on session. */
+		inner class SessionAssert(learnerSession: SciconumLearnerSessionEntity) {
+			private val learnerSession = tx.execute { learnerSession.freshCopy() }
 
-		fun <T : E, U : E, V : E, W : E> refresh(e1: T, e2: U, e3: V, e4: W): Quadruple<T, U, V, W> =
-			tx.execute { Quadruple(e1.refresh0(), e2.refresh0(), e3.refresh0(), e4.refresh0()) }
+			/** Asserts that the session is in the specified [phase]. */
+			fun isInPhase(phase: SciconumScenarioExecutionPhase) = also {
+				assertThat(learnerSession.phase).isEqualTo(phase)
+			}
+
+			/** Asserts that the session is in the specified [phase]. */
+			fun isNotInPhase(phase: SciconumScenarioExecutionPhase) = also {
+				assertThat(learnerSession.phase).isNotEqualTo(phase)
+			}
+		}
+
+		/** Assertions on sessions. */
+		inner class SessionsAssert(learnerSessions: Array<out SciconumLearnerSessionEntity>) {
+			private val learnerSessions = tx.execute { learnerSessions.freshCopies() }
+
+			init {
+				require(this.learnerSessions.isNotEmpty())
+			}
+
+			/** Asserts that all sessions are in the specified [phase]. */
+			fun areInPhase(phase: SciconumScenarioExecutionPhase) = also {
+				for (session in learnerSessions) {
+					assertThat(session.phase).isEqualTo(phase)
+				}
+			}
+
+			/** Asserts that all sessions are in the specified [phase]. */
+			fun areNotInPhase(phase: SciconumScenarioExecutionPhase) = also {
+				for (session in learnerSessions) {
+					assertThat(session.phase).isNotEqualTo(phase)
+				}
+			}
+		}
+
+		/** Assertions on sessions. */
+		inner class AllSessionsAssert(extraSessions: Array<out SciconumLearnerSessionEntity>) {
+			private val scenarioSession = tx.execute { this@TimedFlowDsl.scenarioSession.freshCopy() }
+			private val learnerSessions = tx.execute { (learners.values + extraSessions).freshCopies() }
+
+			/** Asserts that all sessions are in the specified [phase]. */
+			fun areInPhase(phase: SciconumScenarioExecutionPhase) = also {
+				assertThat(scenarioSession.phase).isEqualTo(phase)
+				for (session in learnerSessions) {
+					assertThat(session.phase).isEqualTo(phase)
+				}
+			}
+
+			/** Asserts that all sessions are in the specified [phase]. */
+			fun areNotInPhase(phase: SciconumScenarioExecutionPhase) = also {
+				assertThat(scenarioSession.phase).isNotEqualTo(phase)
+				for (session in learnerSessions) {
+					assertThat(session.phase).isNotEqualTo(phase)
+				}
+			}
+
+			/** Asserts that the global session is at the [question]-th question. */
+			fun areAtNthQuestion(question: UInt) = also {
+				require(question != 0u) // When we say it's "nth", it's ACTUALLY nth and not actually 0-indexed :)
+				assertThat(scenarioSession.currentRound).isEqualTo(question - 1u)
+			}
+
+			/** Asserts that the global session is at the [question]-th question. */
+			fun areNotAtNthQuestion(question: UInt) = also {
+				require(question != 0u) // When we say it's "nth", it's ACTUALLY nth and not actually 0-indexed :)
+				assertThat(scenarioSession.currentRound).isNotEqualTo(question - 1u)
+			}
+		}
 	}
-
-	data class Quadruple<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
 }

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/AbstractSciconumFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/AbstractSciconumFlowTest.kt
@@ -79,7 +79,7 @@ abstract class AbstractSciconumFlowTest : SciconumIntegrationTest() {
 		/**
 		 * Starts the execution of the test scenario.
 		 */
-		fun start() = sciconumScenarioExecutionService.startSequence(scenarioSession)
+		fun start() = sciconumScenarioExecutionService.startSequenceScenarioSessionById(scenarioSession.id)
 
 		/**
 		 * Advances the clock by [duration].

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumAssessmentFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumAssessmentFlowTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec.flow
+
+import org.assertj.core.api.Assertions.assertThat
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.server.scenario.SciconumScenario
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.time.Duration.Companion.minutes
+import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase as Phase
+
+@SpringBootTest
+@OptIn(SciconumTechDebt::class)
+class SciconumAssessmentFlowTest : AbstractSciconumFlowTest() {
+	@Test
+	fun `PA sequence executes according to planned scenario`() {
+		validateScenario(SciconumScenario.PEER_ASSESSMENT, 4u) {
+			val (_, session1) = createLearner()
+			val (_, session2) = createLearner()
+
+			fun checkState(phase: Phase, question: UInt) {
+				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
+				assertThat(gs.phase).isEqualTo(phase)
+				assertThat(gs.currentRound).isEqualTo(question)
+				assertThat(s1.phase).isEqualTo(phase)
+				assertThat(s2.phase).isEqualTo(phase)
+			}
+
+			checkState(Phase.PENDING, 0u)
+			start()
+			checkState(Phase.QUESTION, 0u)
+
+			advanceClock(2.minutes)
+			checkState(Phase.PEER, 0u)
+			// TODO: Check peering
+
+			advanceClock(3.5.minutes)
+			checkState(Phase.REVISE, 0u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 0u)
+
+			advanceClock(1.5.minutes)
+			checkState(Phase.QUESTION, 1u)
+
+			advanceClock(2.minutes)
+			checkState(Phase.PEER, 1u)
+			// TODO: Check peering
+
+			advanceClock(3.5.minutes)
+			checkState(Phase.REVISE, 1u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 1u)
+
+			advanceClock(1.5.minutes)
+			checkState(Phase.QUESTION, 2u)
+
+			advanceClock(2.minutes)
+			checkState(Phase.PEER, 2u)
+			// TODO: Check peering
+
+			advanceClock(3.5.minutes)
+			checkState(Phase.REVISE, 2u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 2u)
+
+			advanceClock(1.5.minutes)
+			checkState(Phase.QUESTION, 3u)
+
+			advanceClock(2.minutes)
+			checkState(Phase.PEER, 3u)
+			// TODO: Check peering
+
+			advanceClock(3.5.minutes)
+			checkState(Phase.REVISE, 3u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 3u)
+
+			advanceClock(1.5.minutes)
+			checkState(Phase.END, 4u)
+		}
+	}
+
+	@Test
+	fun `PA late learner can join and will be picked up on next question`() {
+		validateScenario(SciconumScenario.PEER_ASSESSMENT, 4u) {
+			val (_, session1) = createLearner()
+			val (_, session2) = createLearner()
+
+			fun checkState(phase: Phase, question: UInt) {
+				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
+				assertThat(gs.phase).isEqualTo(phase)
+				assertThat(gs.currentRound).isEqualTo(question)
+				assertThat(s1.phase).isEqualTo(phase)
+				assertThat(s2.phase).isEqualTo(phase)
+			}
+
+			checkState(Phase.PENDING, 0u)
+			start()
+
+			advanceClock(
+				2.minutes +
+					3.5.minutes +
+					0.5.minutes +
+					1.5.minutes,
+			)
+			checkState(Phase.QUESTION, 1u)
+
+			val (_, session3) = createLearner()
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+
+			advanceClock(2.minutes)
+			checkState(Phase.PEER, 1u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			// TODO: Check learner has no peering
+
+			advanceClock(3.5.minutes)
+			checkState(Phase.REVISE, 1u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 1u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+
+			advanceClock(1.5.minutes)
+			checkState(Phase.QUESTION, 2u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.QUESTION)
+		}
+	}
+}

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumAssessmentFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumAssessmentFlowTest.kt
@@ -19,7 +19,6 @@
 
 package org.elaastix.server.scenario.exec.flow
 
-import org.assertj.core.api.Assertions.assertThat
 import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.scenario.SciconumScenario
 import org.junit.jupiter.api.Test
@@ -32,120 +31,101 @@ import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase as Phase
 class SciconumAssessmentFlowTest : AbstractSciconumFlowTest() {
 	@Test
 	fun `PA sequence executes according to planned scenario`() {
-		validateScenario(SciconumScenario.PEER_ASSESSMENT, 4u) {
-			val (_, session1) = createLearner()
-			val (_, session2) = createLearner()
-
-			fun checkState(phase: Phase, question: UInt) {
-				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
-				assertThat(gs.phase).isEqualTo(phase)
-				assertThat(gs.currentRound).isEqualTo(question)
-				assertThat(s1.phase).isEqualTo(phase)
-				assertThat(s2.phase).isEqualTo(phase)
-			}
-
-			checkState(Phase.PENDING, 0u)
+		validateScenario(SciconumScenario.PEER_ASSESSMENT, 4u, 2u) {
+			assertThatAllSessions().areInPhase(Phase.PENDING)
 			start()
-			checkState(Phase.QUESTION, 0u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.PEER, 0u)
+			assertThatAllSessions()
+				.areInPhase(Phase.QUESTION)
+				.areAtNthQuestion(1u)
+
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 2.minutes)
+			assertThatAllSessions().areAtNthQuestion(1u)
 			// TODO: Check peering
 
-			advanceClock(3.5.minutes)
-			checkState(Phase.REVISE, 0u)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 3.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(1u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 0u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(1u)
 
-			advanceClock(1.5.minutes)
-			checkState(Phase.QUESTION, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 1.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.PEER, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 2.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 			// TODO: Check peering
 
-			advanceClock(3.5.minutes)
-			checkState(Phase.REVISE, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 3.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(1.5.minutes)
-			checkState(Phase.QUESTION, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 1.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.PEER, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 2.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 			// TODO: Check peering
 
-			advanceClock(3.5.minutes)
-			checkState(Phase.REVISE, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 3.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 
-			advanceClock(1.5.minutes)
-			checkState(Phase.QUESTION, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 1.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.PEER, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 2.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 			// TODO: Check peering
 
-			advanceClock(3.5.minutes)
-			checkState(Phase.REVISE, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 3.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 
-			advanceClock(1.5.minutes)
-			checkState(Phase.END, 4u)
+			checkTransitionToPhaseAfter(phase = Phase.END, after = 1.5.minutes)
 		}
 	}
 
 	@Test
 	fun `PA late learner can join and will be picked up on next question`() {
-		validateScenario(SciconumScenario.PEER_ASSESSMENT, 4u) {
-			val (_, session1) = createLearner()
-			val (_, session2) = createLearner()
-
-			fun checkState(phase: Phase, question: UInt) {
-				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
-				assertThat(gs.phase).isEqualTo(phase)
-				assertThat(gs.currentRound).isEqualTo(question)
-				assertThat(s1.phase).isEqualTo(phase)
-				assertThat(s2.phase).isEqualTo(phase)
-			}
-
-			checkState(Phase.PENDING, 0u)
+		validateScenario(SciconumScenario.PEER_ASSESSMENT, 4u, 2u) {
+			assertThatAllSessions().areInPhase(Phase.PENDING)
 			start()
 
-			advanceClock(
-				2.minutes +
+			checkTransitionToPhaseAfter(
+				phase = Phase.QUESTION,
+				after = 2.minutes +
 					3.5.minutes +
 					0.5.minutes +
 					1.5.minutes,
 			)
-			checkState(Phase.QUESTION, 1u)
 
-			val (_, session3) = createLearner()
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.PEER, 1u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			val (_, lateLearnerSession) = createLearner()
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 2.minutes)
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 			// TODO: Check learner has no peering
 
-			advanceClock(3.5.minutes)
-			checkState(Phase.REVISE, 1u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 3.5.minutes)
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 1u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(1.5.minutes)
-			checkState(Phase.QUESTION, 2u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.QUESTION)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 1.5.minutes, lateLearnerSession)
+			assertThatAllSessions(lateLearnerSession).areAtNthQuestion(3u)
 		}
 	}
 }

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumControlFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumControlFlowTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec.flow
+
+import org.assertj.core.api.Assertions.assertThat
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.server.scenario.SciconumScenario
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.time.Duration.Companion.minutes
+import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase as Phase
+
+@SpringBootTest
+@OptIn(SciconumTechDebt::class)
+class SciconumControlFlowTest : AbstractSciconumFlowTest() {
+	@Test
+	fun `control sequence executes according to planned scenario`() {
+		validateScenario(SciconumScenario.CONTROL, 4u) {
+			val (_, session1) = createLearner()
+			val (_, session2) = createLearner()
+
+			fun checkState(phase: Phase, question: UInt) {
+				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
+				assertThat(gs.phase).isEqualTo(phase)
+				assertThat(gs.currentRound).isEqualTo(question)
+				assertThat(s1.phase).isEqualTo(phase)
+				assertThat(s2.phase).isEqualTo(phase)
+			}
+
+			checkState(Phase.PENDING, 0u)
+
+			start()
+			checkState(Phase.QUESTION, 0u)
+
+			advanceClock(2.minutes)
+			checkState(Phase.FEEDBACK, 0u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.QUESTION, 1u)
+
+			advanceClock(2.minutes)
+			checkState(Phase.FEEDBACK, 1u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.QUESTION, 2u)
+
+			advanceClock(2.minutes)
+			checkState(Phase.FEEDBACK, 2u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.QUESTION, 3u)
+
+			advanceClock(2.minutes)
+			checkState(Phase.FEEDBACK, 3u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.END, 4u)
+		}
+	}
+
+	@Test
+	fun `control late learner can join and will be picked up on next question`() {
+		validateScenario(SciconumScenario.CONTROL, 4u) {
+			val (_, session1) = createLearner()
+			val (_, session2) = createLearner()
+
+			fun checkState(phase: Phase, question: UInt) {
+				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
+				assertThat(gs.phase).isEqualTo(phase)
+				assertThat(gs.currentRound).isEqualTo(question)
+				assertThat(s1.phase).isEqualTo(phase)
+				assertThat(s2.phase).isEqualTo(phase)
+			}
+
+			checkState(Phase.PENDING, 0u)
+			start()
+
+			advanceClock(2.5.minutes)
+			checkState(Phase.QUESTION, 1u)
+
+			val (_, session3) = createLearner()
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+
+			advanceClock(2.minutes)
+			checkState(Phase.FEEDBACK, 1u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.QUESTION, 2u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.QUESTION)
+
+			advanceClock(5.minutes)
+			checkState(Phase.END, 4u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.END)
+		}
+	}
+}

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumControlFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumControlFlowTest.kt
@@ -19,7 +19,6 @@
 
 package org.elaastix.server.scenario.exec.flow
 
-import org.assertj.core.api.Assertions.assertThat
 import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.scenario.SciconumScenario
 import org.junit.jupiter.api.Test
@@ -32,83 +31,59 @@ import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase as Phase
 class SciconumControlFlowTest : AbstractSciconumFlowTest() {
 	@Test
 	fun `control sequence executes according to planned scenario`() {
-		validateScenario(SciconumScenario.CONTROL, 4u) {
-			val (_, session1) = createLearner()
-			val (_, session2) = createLearner()
-
-			fun checkState(phase: Phase, question: UInt) {
-				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
-				assertThat(gs.phase).isEqualTo(phase)
-				assertThat(gs.currentRound).isEqualTo(question)
-				assertThat(s1.phase).isEqualTo(phase)
-				assertThat(s2.phase).isEqualTo(phase)
-			}
-
-			checkState(Phase.PENDING, 0u)
+		validateScenario(SciconumScenario.CONTROL, 4u, 2u) {
+			assertThatAllSessions().areInPhase(Phase.PENDING)
 
 			start()
-			checkState(Phase.QUESTION, 0u)
+			assertThatAllSessions()
+				.areInPhase(Phase.QUESTION)
+				.areAtNthQuestion(1u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.FEEDBACK, 0u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 2.minutes)
+			assertThatAllSessions().areAtNthQuestion(1u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.QUESTION, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.FEEDBACK, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 2.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.QUESTION, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.FEEDBACK, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 2.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.QUESTION, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 
-			advanceClock(2.minutes)
-			checkState(Phase.FEEDBACK, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 2.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.END, 4u)
+			checkTransitionToPhaseAfter(phase = Phase.END, after = 0.5.minutes)
 		}
 	}
 
 	@Test
 	fun `control late learner can join and will be picked up on next question`() {
-		validateScenario(SciconumScenario.CONTROL, 4u) {
-			val (_, session1) = createLearner()
-			val (_, session2) = createLearner()
-
-			fun checkState(phase: Phase, question: UInt) {
-				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
-				assertThat(gs.phase).isEqualTo(phase)
-				assertThat(gs.currentRound).isEqualTo(question)
-				assertThat(s1.phase).isEqualTo(phase)
-				assertThat(s2.phase).isEqualTo(phase)
-			}
-
-			checkState(Phase.PENDING, 0u)
+		validateScenario(SciconumScenario.CONTROL, 4u, 2u) {
+			assertThatAllSessions().areInPhase(Phase.PENDING)
 			start()
 
-			advanceClock(2.5.minutes)
-			checkState(Phase.QUESTION, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 2.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			val (_, session3) = createLearner()
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			val (_, lateLearnerSession) = createLearner()
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
 
-			advanceClock(2.minutes)
-			checkState(Phase.FEEDBACK, 1u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 2.minutes)
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.QUESTION, 2u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.QUESTION)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 0.5.minutes, lateLearnerSession)
+			assertThatAllSessions(lateLearnerSession).areAtNthQuestion(3u)
 
-			advanceClock(5.minutes)
-			checkState(Phase.END, 4u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.END)
+			checkTransitionToPhaseAfter(phase = Phase.END, after = 5.minutes, lateLearnerSession)
 		}
 	}
 }

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumDebateFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumDebateFlowTest.kt
@@ -19,7 +19,6 @@
 
 package org.elaastix.server.scenario.exec.flow
 
-import org.assertj.core.api.Assertions.assertThat
 import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.scenario.SciconumScenario
 import org.junit.jupiter.api.Test
@@ -32,120 +31,101 @@ import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase as Phase
 class SciconumDebateFlowTest : AbstractSciconumFlowTest() {
 	@Test
 	fun `PD sequence executes according to planned scenario`() {
-		validateScenario(SciconumScenario.PEER_DEBATE, 4u) {
-			val (_, session1) = createLearner()
-			val (_, session2) = createLearner()
-
-			fun checkState(phase: Phase, question: UInt) {
-				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
-				assertThat(gs.phase).isEqualTo(phase)
-				assertThat(gs.currentRound).isEqualTo(question)
-				assertThat(s1.phase).isEqualTo(phase)
-				assertThat(s2.phase).isEqualTo(phase)
-			}
-
-			checkState(Phase.PENDING, 0u)
+		validateScenario(SciconumScenario.PEER_DEBATE, 4u, 2u) {
+			assertThatAllSessions().areInPhase(Phase.PENDING)
 			start()
-			checkState(Phase.QUESTION, 0u)
 
-			advanceClock(1.minutes)
-			checkState(Phase.PEER, 0u)
+			assertThatAllSessions()
+				.areInPhase(Phase.QUESTION)
+				.areAtNthQuestion(1u)
+
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 1.minutes)
+			assertThatAllSessions().areAtNthQuestion(1u)
 			// TODO: Check peering
 
-			advanceClock(5.5.minutes)
-			checkState(Phase.REVISE, 0u)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 5.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(1u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 0u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(1u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.QUESTION, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(1.minutes)
-			checkState(Phase.PEER, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 1.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 			// TODO: Check peering
 
-			advanceClock(5.5.minutes)
-			checkState(Phase.REVISE, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 5.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 1u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.QUESTION, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 
-			advanceClock(1.minutes)
-			checkState(Phase.PEER, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 1.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 			// TODO: Check peering
 
-			advanceClock(5.5.minutes)
-			checkState(Phase.REVISE, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 5.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 2u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(3u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.QUESTION, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 
-			advanceClock(1.minutes)
-			checkState(Phase.PEER, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 1.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 			// TODO: Check peering
 
-			advanceClock(5.5.minutes)
-			checkState(Phase.REVISE, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 5.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 3u)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatAllSessions().areAtNthQuestion(4u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.END, 4u)
+			checkTransitionToPhaseAfter(phase = Phase.END, after = 0.5.minutes)
 		}
 	}
 
 	@Test
 	fun `PD late learner can join and will be picked up on next question`() {
-		validateScenario(SciconumScenario.PEER_DEBATE, 4u) {
-			val (_, session1) = createLearner()
-			val (_, session2) = createLearner()
-
-			fun checkState(phase: Phase, question: UInt) {
-				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
-				assertThat(gs.phase).isEqualTo(phase)
-				assertThat(gs.currentRound).isEqualTo(question)
-				assertThat(s1.phase).isEqualTo(phase)
-				assertThat(s2.phase).isEqualTo(phase)
-			}
-
-			checkState(Phase.PENDING, 0u)
+		validateScenario(SciconumScenario.PEER_DEBATE, 4u, 2u) {
+			assertThatAllSessions().areInPhase(Phase.PENDING)
 			start()
 
-			advanceClock(
-				1.minutes +
+			checkTransitionToPhaseAfter(
+				phase = Phase.QUESTION,
+				after = 1.minutes +
 					5.5.minutes +
 					0.5.minutes +
 					0.5.minutes,
 			)
-			checkState(Phase.QUESTION, 1u)
 
-			val (_, session3) = createLearner()
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(1.minutes)
-			checkState(Phase.PEER, 1u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			val (_, lateLearnerSession) = createLearner()
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+
+			checkTransitionToPhaseAfter(phase = Phase.PEER, after = 1.minutes)
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 			// TODO: Check learner has no peering
 
-			advanceClock(5.5.minutes)
-			checkState(Phase.REVISE, 1u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			checkTransitionToPhaseAfter(phase = Phase.REVISE, after = 5.5.minutes)
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.FEEDBACK, 1u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			checkTransitionToPhaseAfter(phase = Phase.FEEDBACK, after = 0.5.minutes)
+			assertThatSpecificSession(lateLearnerSession).isInPhase(Phase.PENDING)
+			assertThatAllSessions().areAtNthQuestion(2u)
 
-			advanceClock(0.5.minutes)
-			checkState(Phase.QUESTION, 2u)
-			assertThat(session3.refresh().phase).isEqualTo(Phase.QUESTION)
+			checkTransitionToPhaseAfter(phase = Phase.QUESTION, after = 0.5.minutes, lateLearnerSession)
+			assertThatAllSessions(lateLearnerSession).areAtNthQuestion(3u)
 		}
 	}
 }

--- a/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumDebateFlowTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/scenario/exec/flow/SciconumDebateFlowTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec.flow
+
+import org.assertj.core.api.Assertions.assertThat
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.server.scenario.SciconumScenario
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.time.Duration.Companion.minutes
+import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase as Phase
+
+@SpringBootTest
+@OptIn(SciconumTechDebt::class)
+class SciconumDebateFlowTest : AbstractSciconumFlowTest() {
+	@Test
+	fun `PD sequence executes according to planned scenario`() {
+		validateScenario(SciconumScenario.PEER_DEBATE, 4u) {
+			val (_, session1) = createLearner()
+			val (_, session2) = createLearner()
+
+			fun checkState(phase: Phase, question: UInt) {
+				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
+				assertThat(gs.phase).isEqualTo(phase)
+				assertThat(gs.currentRound).isEqualTo(question)
+				assertThat(s1.phase).isEqualTo(phase)
+				assertThat(s2.phase).isEqualTo(phase)
+			}
+
+			checkState(Phase.PENDING, 0u)
+			start()
+			checkState(Phase.QUESTION, 0u)
+
+			advanceClock(1.minutes)
+			checkState(Phase.PEER, 0u)
+			// TODO: Check peering
+
+			advanceClock(5.5.minutes)
+			checkState(Phase.REVISE, 0u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 0u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.QUESTION, 1u)
+
+			advanceClock(1.minutes)
+			checkState(Phase.PEER, 1u)
+			// TODO: Check peering
+
+			advanceClock(5.5.minutes)
+			checkState(Phase.REVISE, 1u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 1u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.QUESTION, 2u)
+
+			advanceClock(1.minutes)
+			checkState(Phase.PEER, 2u)
+			// TODO: Check peering
+
+			advanceClock(5.5.minutes)
+			checkState(Phase.REVISE, 2u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 2u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.QUESTION, 3u)
+
+			advanceClock(1.minutes)
+			checkState(Phase.PEER, 3u)
+			// TODO: Check peering
+
+			advanceClock(5.5.minutes)
+			checkState(Phase.REVISE, 3u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 3u)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.END, 4u)
+		}
+	}
+
+	@Test
+	fun `PD late learner can join and will be picked up on next question`() {
+		validateScenario(SciconumScenario.PEER_DEBATE, 4u) {
+			val (_, session1) = createLearner()
+			val (_, session2) = createLearner()
+
+			fun checkState(phase: Phase, question: UInt) {
+				val (gs, s1, s2) = refresh(scenarioSession, session1, session2)
+				assertThat(gs.phase).isEqualTo(phase)
+				assertThat(gs.currentRound).isEqualTo(question)
+				assertThat(s1.phase).isEqualTo(phase)
+				assertThat(s2.phase).isEqualTo(phase)
+			}
+
+			checkState(Phase.PENDING, 0u)
+			start()
+
+			advanceClock(
+				1.minutes +
+					5.5.minutes +
+					0.5.minutes +
+					0.5.minutes,
+			)
+			checkState(Phase.QUESTION, 1u)
+
+			val (_, session3) = createLearner()
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+
+			advanceClock(1.minutes)
+			checkState(Phase.PEER, 1u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+			// TODO: Check learner has no peering
+
+			advanceClock(5.5.minutes)
+			checkState(Phase.REVISE, 1u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.FEEDBACK, 1u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.PENDING)
+
+			advanceClock(0.5.minutes)
+			checkState(Phase.QUESTION, 2u)
+			assertThat(session3.refresh().phase).isEqualTo(Phase.QUESTION)
+		}
+	}
+}

--- a/server/src/test/kotlin/testutils/ControllableClock.kt
+++ b/server/src/test/kotlin/testutils/ControllableClock.kt
@@ -1,0 +1,232 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package testutils
+
+import org.elaastix.commons.platform.Unsafe
+import org.springframework.scheduling.SchedulingException
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.Trigger
+import org.springframework.scheduling.support.SimpleTriggerContext
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.PriorityQueue
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Delayed
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.time.toDurationUnit
+import kotlin.time.toJavaInstant
+import kotlin.time.toKotlinInstant
+import java.time.Clock as JClock
+import java.time.Duration as JDuration
+import java.time.Instant as JInstant
+
+/**
+ * An implementation of [Clock] and [JClock] that is controllable, for use in tests.
+ *
+ * Instances of the clock also provide a virtual task scheduler that is aware of the faked time.
+ * When time is moved forward, the clock will do a best-effort job at executing scheduled tasks "as expected".
+ *
+ * The clock is internally isolated per-thread, making it compatible with concurrent test execution.
+ */
+class ControllableClock :
+	JClock(),
+	Clock {
+	// Could also pick a random start point...
+	private val instant = ThreadLocal.withInitial { Clock.System.now() }
+
+	val scheduler = ControllableClockAwareTaskScheduler()
+
+	override fun now(): Instant = instant.get()
+
+	override fun getZone(): ZoneId = ZoneOffset.UTC
+	override fun withZone(zone: ZoneId): JClock = ZonedClock(this, zone)
+	override fun instant() = instant.get().toJavaInstant()
+
+	/**
+	 * Moves the clock forwards in time.
+	 *
+	 * This operation will notify the [scheduler], which will synchronously run all tasks that are expected to run
+	 * before or at `now + duration`.
+	 *
+	 * Scheduled tasks will be run in strict order, and will observe the exact time at which they've been scheduled on
+	 * the clock. Periodic tasks may run multiple time if the increment covers multiple executions of the task.
+	 *
+	 * As the scheduler runs the tasks synchronously, any exception thrown in a task will fail the test. This is a
+	 * strongly desirable behaviour, as this lets the test framework capture the exception and fail the test as soon as
+	 * it occurs.
+	 *
+	 * @throws org.springframework.scheduling.SchedulingException if an exception occurs while running scheduled tasks.
+	 */
+	fun add(duration: Duration) {
+		val targetTime = instant.get().plus(duration)
+		scheduler.tick(targetTime)
+		instant.set(targetTime)
+	}
+
+	/**
+	 * Moves the clock backwards in time.
+	 *
+	 * This operation is [Unsafe], as clock rollbacks (while theoretically expected) are undesired and break
+	 * the "natural" passage of time and causes ambiguity with scheduled tasks.
+	 *
+	 * The scheduler will not run any task, and the next execution of currently scheduled tasks will not be affected.
+	 * This includes recurring scheduled tasks, which means they will only run periodically until time reaches the
+	 * currently next planned execution.
+	 *
+	 * In other words, if a task is scheduled to run every 10 seconds, and the clock is moved back 1 minute, then the
+	 * next execution of the task will be in (approximately) 70 seconds. Its second next execution will be 10 seconds
+	 * after that, so in 80 seconds. Its reference point will not be moved back.
+	 */
+	@Unsafe
+	fun sub(duration: Duration) {
+		instant.set(instant.get().minus(duration))
+	}
+
+	/**
+	 * Moves the clock to a specific instant. The target instant MUST be in the future.
+	 *
+	 * For moving the clock to an earlier [Instant], see the **unsafe** variant [moveUnchecked].
+	 *
+	 * @throws IllegalArgumentException if [instant] is earlier than the current time.
+	 * @throws SchedulingException if an exception occurs while running scheduled tasks.
+	 */
+	fun move(instant: Instant) {
+		// Thread safety: because the value is thread local, there's no risk of a reading a stale value.
+		require(instant > this.instant.get())
+		scheduler.tick(instant)
+		this.instant.set(instant)
+	}
+
+	/**
+	 * Moves the clock to a specific instant, **without ticking the scheduler**.
+	 * Does not check whether [instant] is in the future or past either.
+	 *
+	 * See [sub]'s documentation for the implications of moving the clock backwards.
+	 */
+	@Unsafe
+	fun moveUnchecked(instant: Instant) {
+		this.instant.set(instant)
+	}
+
+	inner class ControllableClockAwareTaskScheduler : TaskScheduler {
+		private val tasks = ThreadLocal.withInitial { PriorityQueue<Task>() }
+
+		fun tick(targetTime: Instant) {
+			val queue = tasks.get()
+			while (queue.peek()?.let { it.scheduledAt <= targetTime } == true) {
+				val task = queue.remove()
+				if (task.isCancelled) continue
+
+				instant.set(task.scheduledAt)
+				if (!task.run()) {
+					throw SchedulingException(
+						"An exception occurred while running a scheduled task",
+						task.exceptionNow(),
+					)
+				}
+
+				val ctx = createTriggerContext(task.scheduledAt)
+				task.trigger.nextExecution(ctx)
+					?.let { next -> queue.add(task.rerunAt(next.toKotlinInstant())) }
+					?: task.future.complete(Unit)
+			}
+		}
+
+		private fun scheduleChecked(task: Runnable, trigger: Trigger) = checkNotNull(schedule(task, trigger))
+
+		override fun schedule(task: Runnable, trigger: Trigger): ScheduledFuture<*>? {
+			val ctx = createTriggerContext(null)
+			val next = trigger.nextExecution(ctx)?.toKotlinInstant() ?: return null
+			return Task(task, next, trigger, this@ControllableClock).also {
+				tasks.get().add(it)
+				tick(now())
+			}
+		}
+
+		override fun schedule(task: Runnable, jStartTime: JInstant) =
+			scheduleChecked(task) { if (it.lastCompletion() == null) jStartTime else null }
+
+		override fun scheduleAtFixedRate(task: Runnable, jStartTime: JInstant, jPeriod: JDuration) =
+			scheduleChecked(task) {
+				val prev = it.lastActualExecution() ?: jStartTime
+				prev.plus(jPeriod)
+			}
+
+		override fun scheduleWithFixedDelay(task: Runnable, jStartTime: JInstant, jDelay: JDuration) =
+			scheduleChecked(task) {
+				val prev = it.lastCompletion() ?: jStartTime
+				prev.plus(jDelay)
+			}
+
+		override fun scheduleAtFixedRate(task: Runnable, jPeriod: JDuration) =
+			scheduleAtFixedRate(task, instant(), jPeriod)
+
+		override fun scheduleWithFixedDelay(task: Runnable, jDelay: JDuration) =
+			scheduleWithFixedDelay(task, instant(), jDelay)
+
+		// We completely mock the passage of time, so all 3 values of the trigger context are artificially equal:
+		// - The scheduler will "perfectly" execute the task at the exact nanosecond it's supposed to
+		// - The task will take zero second since we're not using wall clock
+		private fun createTriggerContext(instant: Instant?) =
+			SimpleTriggerContext(this@ControllableClock).apply {
+				update(instant?.toJavaInstant(), instant?.toJavaInstant(), instant?.toJavaInstant())
+			}
+	}
+
+	private class Task(
+		val task: Runnable,
+		val scheduledAt: Instant,
+		val trigger: Trigger,
+		val clock: Clock,
+		val future: CompletableFuture<Unit> = CompletableFuture<Unit>(),
+	) : ScheduledFuture<Unit> {
+
+		fun run() =
+			runCatching { task.run() }
+				.onFailure { future.completeExceptionally(it) }
+				.isSuccess
+
+		fun rerunAt(next: Instant) = Task(task, next, trigger, clock, future)
+
+		override fun cancel(mayInterruptIfRunning: Boolean): Boolean = future.cancel(mayInterruptIfRunning)
+		override fun isCancelled(): Boolean = future.isCancelled()
+		override fun isDone(): Boolean = future.isDone
+		override fun get(): Unit = future.get()
+		override fun get(timeout: Long, unit: TimeUnit): Unit = future.get(timeout, unit)
+
+		override fun getDelay(unit: TimeUnit) = (scheduledAt - clock.now()).toLong(unit.toDurationUnit())
+		override fun compareTo(other: Delayed) =
+			getDelay(TimeUnit.NANOSECONDS).compareTo(other.getDelay(TimeUnit.NANOSECONDS))
+	}
+
+	private class ZonedClock(private val source: JClock, private val zone: ZoneId) : JClock() {
+		override fun getZone() = zone
+		override fun withZone(zone: ZoneId) = ZonedClock(source, zone)
+		override fun instant(): JInstant = source.instant()
+
+		override fun equals(obj: Any?) = obj is ZonedClock && source == obj.source && zone == obj.zone
+		override fun hashCode() = source.hashCode() * 31 + zone.hashCode()
+		override fun toString() = "ControllableClock#Zoned[$zone]"
+	}
+}

--- a/server/src/test/kotlin/testutils/IntegrationTest.kt
+++ b/server/src/test/kotlin/testutils/IntegrationTest.kt
@@ -28,7 +28,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Primary
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionTemplate
@@ -40,6 +44,7 @@ import kotlin.time.Clock
 	],
 )
 @AutoConfigureMockMvc
+@Import(IntegrationTest.TestSchedulerConfig::class)
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
 abstract class IntegrationTest {
 	companion object {
@@ -53,7 +58,7 @@ abstract class IntegrationTest {
 	lateinit var mvc: MockMvc
 
 	@Autowired
-	private lateinit var tx: TransactionTemplate
+	lateinit var tx: TransactionTemplate
 
 	private lateinit var testInfo: TestInfo
 
@@ -78,5 +83,16 @@ abstract class IntegrationTest {
 		val iso = Clock.System.now().toIsoStringSecondPrecise()
 
 		return "$clazz#`$name` @ $iso"
+	}
+
+	@TestConfiguration
+	class TestSchedulerConfig {
+		@Bean
+		@Primary
+		fun controllableClock() = ControllableClock()
+
+		@Bean
+		@Primary
+		fun syntheticScheduler(clock: ControllableClock) = clock.scheduler
 	}
 }

--- a/server/src/test/kotlin/testutils/IntegrationTest.kt
+++ b/server/src/test/kotlin/testutils/IntegrationTest.kt
@@ -34,7 +34,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.support.TransactionTemplate
 import kotlin.time.Clock
 
@@ -67,9 +66,7 @@ abstract class IntegrationTest {
 		this.testInfo = testInfo
 	}
 
-	fun <T> runWithTransaction(block: (TransactionStatus) -> T): T = tx.execute(block)
-
-	fun <T : AbstractEntity> T.persist() = also { runWithTransaction { em.persist(this) } }
+	fun <T : AbstractEntity> T.persist() = also { tx.execute { em.persist(this) } }
 
 	fun makeRecognisableName(): String {
 		// Target maximum length: 64

--- a/server/src/test/kotlin/testutils/IntegrationTest.kt
+++ b/server/src/test/kotlin/testutils/IntegrationTest.kt
@@ -68,6 +68,11 @@ abstract class IntegrationTest {
 
 	fun <T : AbstractEntity> T.persist() = also { tx.execute { em.persist(this) } }
 
+	fun <T : AbstractEntity> T.freshCopy(): T = em.find(this::class.java, id)
+
+	fun <T : AbstractEntity> Iterable<T>.freshCopies(): List<T> = map { em.find(it::class.java, it.id) }
+	fun <T : AbstractEntity> Array<T>.freshCopies(): List<T> = map { em.find(it::class.java, it.id) }
+
 	fun makeRecognisableName(): String {
 		// Target maximum length: 64
 		// Structure: <class>#`<name>` @ <iso-time>


### PR DESCRIPTION
Closes: #187
Closes: #191
Relates to: #182
Relates to: #174

Implemented via local task scheduling, with a complete implementation of a controllable clock and virtual task scheduler in tests.

In tests, the task scheduler is bound to the controllable clock instance. When the clock is moved forward, that operation synchronously triggers scheduled tasks in order, with the clock set to a consistent value (the task observes the time at which it was scheduled to run).

The synchronous execution via the virtual task scheduler makes testing a lot more practical: we can deterministically move the clock to the point in time we're interested in, and because the execution is not asynchronous any exception thrown inside a scheduled task is correctly surfaced to the test framework, causing the test to fail with actionnable insight.

An advanced test harness has been put together to assess with certainty the compliance of the scenario execution with the scenarios specified for the experiments.

Note on mocked time: while mocks generally reduce the confidence in tests, I am strongly confident the task scheduler implemented here is very robust and representative of a real scheduler using wall clock time. Testing more than what's tested here would be in "testing the framework" territorry and not of much use.