### PR TITLE
feat: scenario session binding and checks

### DIFF
--- a/commons/core/src/main/kotlin/org/elaastix/commons/data/Uuid.kt
+++ b/commons/core/src/main/kotlin/org/elaastix/commons/data/Uuid.kt
@@ -99,4 +99,7 @@ object UuidSerializer : KSerializer<KtUuid> {
 
 		return fromByteArray(bytes)
 	}
+
+	/** Attempts to parse a base-36 encoded string into a Uuid. */
+	fun KtUuid.Companion.tryFromBase36(str: String) = runCatching { fromBase36(str) }
 }

--- a/server/src/main/kotlin/org/elaastix/server/activities/response/ResponseActivityController.kt
+++ b/server/src/main/kotlin/org/elaastix/server/activities/response/ResponseActivityController.kt
@@ -22,10 +22,15 @@ package org.elaastix.server.activities.response
 import kotlinx.serialization.Serializable
 import org.elaastix.commons.data.Uuid
 import org.elaastix.commons.orElseNotFound
+import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.activities.response.dtos.ResponseSubmitDto
 import org.elaastix.server.core.player.PlayerAction
 import org.elaastix.server.core.player.PlayerController
 import org.elaastix.server.core.player.PlayerQuery
+import org.elaastix.server.scenario.exec.annotation.LearnerSession
+import org.elaastix.server.scenario.exec.annotation.ScenarioSession
+import org.elaastix.server.scenario.exec.entities.SciconumLearnerSessionEntity
+import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -45,8 +50,24 @@ class ResponseActivityController(private val responseActivityService: ResponseAc
 	 * @param id The ID of the question.
 	 * @return The question statement, and available choices for closed questions.
 	 */
-	@PlayerQuery("org.elaastix.response.getQuestion")
+	@PlayerQuery("org.elaastix.response.getQuestion") // TODO: remove?
 	fun getQuestion(@RequestParam id: Uuid) = responseActivityService.findQuestionStatement(id).orElseNotFound()
+
+	/**
+	 * Retrieve the current question statement.
+	 *
+	 * The returned object does not include the expected answer and its explanation.
+	 *
+	 * @param scenarioSession The scenario session.
+	 * @param learnerSession The learner's session.
+	 * @return The question statement, and available choices for closed questions.
+	 */
+	@PlayerQuery("org.elaastix.response.getCurrentQuestion")
+	@OptIn(SciconumTechDebt::class)
+	fun getCurrentQuestion(
+		@ScenarioSession scenarioSession: SciconumScenarioSessionEntity,
+		@LearnerSession learnerSession: SciconumLearnerSessionEntity,
+	) = responseActivityService.findCurrentQuestionStatement(scenarioSession, learnerSession)
 
 	/**
 	 * Submit an answer to a question.
@@ -55,9 +76,25 @@ class ResponseActivityController(private val responseActivityService: ResponseAc
 	 * @throws org.elaastix.commons.exceptions.BadRequestException if the data is invalid.
 	 */
 	@ResponseStatus(HttpStatus.CREATED)
-	@PlayerAction("org.elaastix.response.submitResponse")
+	@PlayerAction("org.elaastix.response.submitResponse") // TODO: remove?
+	@OptIn(SciconumTechDebt::class)
 	fun submitResponse(@RequestBody payload: SubmitAnswerDto) =
 		responseActivityService.submitResponse(payload.questionId, payload.response)
+
+	/**
+	 * Submit an answer to the current question in the scenario question.
+	 *
+	 * @return The created response statement object.
+	 * @throws org.elaastix.commons.exceptions.BadRequestException if the data is invalid.
+	 */
+	@ResponseStatus(HttpStatus.CREATED)
+	@PlayerAction("org.elaastix.response.submitResponseToCurrentQuestion")
+	@OptIn(SciconumTechDebt::class)
+	fun submitResponse(
+		@ScenarioSession scenarioSession: SciconumScenarioSessionEntity,
+		@LearnerSession learnerSession: SciconumLearnerSessionEntity,
+		@RequestBody payload: ResponseSubmitDto,
+	) = responseActivityService.submitResponseToCurrentQuestion(scenarioSession, learnerSession, payload)
 
 	/** Payload for the submitResponse action. */
 	@Serializable

--- a/server/src/main/kotlin/org/elaastix/server/activities/response/ResponseActivityService.kt
+++ b/server/src/main/kotlin/org/elaastix/server/activities/response/ResponseActivityService.kt
@@ -19,11 +19,11 @@
 
 package org.elaastix.server.activities.response
 
-import jakarta.transaction.Transactional
 import jakarta.validation.Valid
 import org.elaastix.commons.data.Uuid
 import org.elaastix.commons.inherits
 import org.elaastix.commons.orElseNotFound
+import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.commons.platform.wip.UnclearAuthorshipOwnership
 import org.elaastix.commons.validate
 import org.elaastix.server.activities.response.dtos.ClosedQuestionStatementDto
@@ -38,17 +38,24 @@ import org.elaastix.server.activities.response.entities.ClosedQuestionEntity
 import org.elaastix.server.activities.response.entities.ClosedResponseEntity
 import org.elaastix.server.activities.response.entities.OpenQuestionEntity
 import org.elaastix.server.activities.response.entities.OpenResponseEntity
+import org.elaastix.server.activities.response.entities.QuestionEntity
 import org.elaastix.server.activities.response.entities.ResponseEntity
 import org.elaastix.server.activities.response.entities.projections.QuestionStatementProjection
 import org.elaastix.server.activities.response.repositories.QuestionRepository
 import org.elaastix.server.activities.response.repositories.ResponseRepository
+import org.elaastix.server.scenario.exec.ScenarioExecutionStatusCheckService
+import org.elaastix.server.scenario.exec.SciconumScenarioExecutionPhase
+import org.elaastix.server.scenario.exec.entities.SciconumLearnerSessionEntity
+import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /** Service responsible for the response activity. */
 @Service
-class ResponseActivityService(
+class ResponseActivityService @SciconumTechDebt constructor(
 	private val questionRepository: QuestionRepository,
 	private val responseRepository: ResponseRepository,
+	private val scenarioExecutionStatusCheckService: ScenarioExecutionStatusCheckService,
 ) {
 	companion object {
 		/** Transforms the DAO-level type into a Service-level type. */
@@ -98,6 +105,30 @@ class ResponseActivityService(
 	 * Finds a question's statement (and available choices if it's a closed question).
 	 */
 	fun findQuestionStatement(id: Uuid) = questionRepository.findQuestionStatementById(id)?.toDto()
+
+	@SciconumTechDebt
+	private fun getCurrentQuestion(
+		scenarioSession: SciconumScenarioSessionEntity,
+		learnerSession: SciconumLearnerSessionEntity,
+	): QuestionEntity {
+		scenarioExecutionStatusCheckService.assertAppropriateScenarioState(
+			scenarioSession,
+			learnerSession,
+			requiredPhase = SciconumScenarioExecutionPhase.QUESTION,
+		)
+
+		return scenarioSession.sequence.sciconumQuestions[scenarioSession.currentRound.toInt()]
+	}
+
+	/**
+	 * Returns the current question for the scenario session.
+	 */
+	@SciconumTechDebt
+	@Transactional(readOnly = true)
+	fun findCurrentQuestionStatement(
+		scenarioSession: SciconumScenarioSessionEntity,
+		learnerSession: SciconumLearnerSessionEntity,
+	) = QuestionStatementProjection.from(getCurrentQuestion(scenarioSession, learnerSession)).toDto()
 
 	/**
 	 * Validates and records a response to a question.
@@ -152,4 +183,15 @@ class ResponseActivityService(
 				validate(response.answer.value.all { it < statement.choices!!.size.toUInt() }) { "Invalid answer." }
 			}
 		}
+
+	/**
+	 * Processes the response to the current question in the scenario.
+	 */
+	@SciconumTechDebt
+	@Transactional
+	fun submitResponseToCurrentQuestion(
+		scenarioSession: SciconumScenarioSessionEntity,
+		learnerSession: SciconumLearnerSessionEntity,
+		response: ResponseSubmitDto,
+	) = submitResponse(getCurrentQuestion(scenarioSession, learnerSession).id, response)
 }

--- a/server/src/main/kotlin/org/elaastix/server/core/player/PlayerController.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/player/PlayerController.kt
@@ -19,12 +19,22 @@
 
 package org.elaastix.server.core.player
 
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Schema
+import org.elaastix.commons.openapi.UuidSchema
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
  * Annotation that conveniently applies the necessary ones for Spring to configure a player controller.
  */
+@Parameter(
+	name = "sessionId",
+	`in` = ParameterIn.QUERY,
+	description = "ID of the learner session to use for the action.",
+	schema = Schema(type = "string", pattern = UuidSchema.PATTERN),
+)
 @RestController
 // Note: endpoints inside the namespace may have their own versioning separate from the API version.
 // The version here only designates the RPC protocol version (which is 1).

--- a/server/src/main/kotlin/org/elaastix/server/core/player/PlayerController.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/player/PlayerController.kt
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController
  * Annotation that conveniently applies the necessary ones for Spring to configure a player controller.
  */
 @Parameter(
+	required = true,
 	name = "sessionId",
 	`in` = ParameterIn.QUERY,
 	description = "ID of the learner session to use for the action.",

--- a/server/src/main/kotlin/org/elaastix/server/core/player/PlayerSystemController.kt
+++ b/server/src/main/kotlin/org/elaastix/server/core/player/PlayerSystemController.kt
@@ -17,27 +17,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.elaastix.commons.security
+package org.elaastix.server.core.player
+
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 /**
- * Roles that may be granted to a user.
- * Used to restrict access via the [RequiresRole] annotation.
+ * Annotation that conveniently applies the necessary ones for Spring to configure a system player controller.
  */
-enum class Role : Authority {
-	/**
-	 * Users with unrestricted access to the platform.
-	 */
-	ADMIN,
-
-	/**
-	 * Users that are permitted to create content on the platform.
-	 *
-	 * TODO: currently everything's been shoved onto this role instead of using more fine grained permissions.
-	 */
-	WRITER,
-
-	/**
-	 * Any successfully authenticated user.
-	 */
-	USER,
-}
+@RestController
+// Note: endpoints inside the namespace may have their own versioning separate from the API version.
+// The version here only designates the RPC protocol version (which is 1).
+@RequestMapping("/player", version = "1+")
+@Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PlayerSystemController

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/ExecutionController.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/ExecutionController.kt
@@ -22,7 +22,7 @@ package org.elaastix.server.scenario.exec
 import org.elaastix.commons.data.Uuid
 import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.core.player.PlayerAction
-import org.elaastix.server.core.player.PlayerController
+import org.elaastix.server.core.player.PlayerSystemController
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 /**
  * Engine-level operations controlling the execution of a sequence session.
  */
-@PlayerController
+@PlayerSystemController
 @SciconumTechDebt
 class ExecutionController(private val scenarioExecutionService: ScenarioExecutionService) {
 	/**

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionStatusCheckService.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/ScenarioExecutionStatusCheckService.kt
@@ -1,0 +1,53 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec
+
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.commons.validate
+import org.elaastix.server.scenario.SciconumScenario
+import org.elaastix.server.scenario.exec.entities.SciconumLearnerSessionEntity
+import org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@SciconumTechDebt("This would be much better handled using a proper layered system using interceptors")
+class ScenarioExecutionStatusCheckService {
+	@Transactional(propagation = Propagation.MANDATORY)
+	fun assertAppropriateScenarioState(
+		scenarioSession: SciconumScenarioSessionEntity,
+		learnerSession: SciconumLearnerSessionEntity,
+		requiredScenario: SciconumScenario? = null,
+		requiredPhase: SciconumScenarioExecutionPhase? = null,
+	) {
+		validate(scenarioSession.pausedAt == null) {
+			"The scenario is currently paused."
+		}
+
+		validate(requiredScenario == null || requiredScenario == scenarioSession.sequence.sciconumScenario) {
+			"This activity is not part of the scenario."
+		}
+
+		validate(requiredPhase == null || learnerSession.phase == requiredPhase) {
+			"This activity is not active yet."
+		}
+	}
+}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/annotation/LearnerSession.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/annotation/LearnerSession.kt
@@ -17,27 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.elaastix.commons.security
+package org.elaastix.server.scenario.exec.annotation
 
 /**
- * Roles that may be granted to a user.
- * Used to restrict access via the [RequiresRole] annotation.
+ * Annotation flagging an HTTP handler's argument to be resolved with
+ * the [org.elaastix.server.scenario.exec.entities.SciconumLearnerSessionEntity].
  */
-enum class Role : Authority {
-	/**
-	 * Users with unrestricted access to the platform.
-	 */
-	ADMIN,
-
-	/**
-	 * Users that are permitted to create content on the platform.
-	 *
-	 * TODO: currently everything's been shoved onto this role instead of using more fine grained permissions.
-	 */
-	WRITER,
-
-	/**
-	 * Any successfully authenticated user.
-	 */
-	USER,
-}
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LearnerSession

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/annotation/LearnerSession.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/annotation/LearnerSession.kt
@@ -19,10 +19,13 @@
 
 package org.elaastix.server.scenario.exec.annotation
 
+import io.swagger.v3.oas.annotations.Hidden
+
 /**
  * Annotation flagging an HTTP handler's argument to be resolved with
  * the [org.elaastix.server.scenario.exec.entities.SciconumLearnerSessionEntity].
  */
+@Hidden
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class LearnerSession

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/annotation/ScenarioSession.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/annotation/ScenarioSession.kt
@@ -19,10 +19,13 @@
 
 package org.elaastix.server.scenario.exec.annotation
 
+import io.swagger.v3.oas.annotations.Hidden
+
 /**
  * Annotation flagging an HTTP handler's argument to be resolved with
  * the [org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity].
  */
+@Hidden
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class ScenarioSession

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/annotation/ScenarioSession.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/annotation/ScenarioSession.kt
@@ -17,27 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.elaastix.commons.security
+package org.elaastix.server.scenario.exec.annotation
 
 /**
- * Roles that may be granted to a user.
- * Used to restrict access via the [RequiresRole] annotation.
+ * Annotation flagging an HTTP handler's argument to be resolved with
+ * the [org.elaastix.server.scenario.exec.entities.SciconumScenarioSessionEntity].
  */
-enum class Role : Authority {
-	/**
-	 * Users with unrestricted access to the platform.
-	 */
-	ADMIN,
-
-	/**
-	 * Users that are permitted to create content on the platform.
-	 *
-	 * TODO: currently everything's been shoved onto this role instead of using more fine grained permissions.
-	 */
-	WRITER,
-
-	/**
-	 * Any successfully authenticated user.
-	 */
-	USER,
-}
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ScenarioSession

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/entities/SciconumLearnerSessionEntity.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/entities/SciconumLearnerSessionEntity.kt
@@ -22,6 +22,7 @@ package org.elaastix.server.scenario.exec.entities
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.ManyToOne
 import jakarta.validation.constraints.NotNull
 import org.elaastix.commons.jpa.entity.AbstractEntity
@@ -34,7 +35,7 @@ import kotlin.time.Instant
 @SciconumTechDebt
 class SciconumLearnerSessionEntity(
 	@NotNull
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.EAGER)
 	var scenarioSession: SciconumScenarioSessionEntity,
 
 	@NotNull

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/internal/ScenarioExecConfiguration.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/internal/ScenarioExecConfiguration.kt
@@ -1,0 +1,44 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec.internal
+
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.server.scenario.exec.repositories.SciconumLearnerSessionRepository
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * Configuration class for scenario execution related Spring configuration.
+ */
+@Configuration
+@SciconumTechDebt
+class ScenarioExecConfiguration(private val learnerSessionRepository: SciconumLearnerSessionRepository) :
+	WebMvcConfigurer {
+	override fun addInterceptors(registry: InterceptorRegistry) {
+		registry.addInterceptor(SessionBinderInterceptor(learnerSessionRepository))
+			.addPathPatterns("/v*/player/**")
+	}
+
+	override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+		resolvers.add(SessionArgumentResolver())
+	}
+}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/internal/SessionArgumentResolver.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/internal/SessionArgumentResolver.kt
@@ -1,0 +1,57 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec.internal
+
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.server.scenario.exec.annotation.LearnerSession
+import org.elaastix.server.scenario.exec.annotation.ScenarioSession
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+/**
+ * Spring argument resolver injecting [ScenarioSession] and [LearnerSession].
+ */
+class SessionArgumentResolver : HandlerMethodArgumentResolver {
+	override fun supportsParameter(parameter: MethodParameter) = parameter.isSession()
+
+	@OptIn(SciconumTechDebt::class)
+	override fun resolveArgument(
+		parameter: MethodParameter,
+		mavContainer: ModelAndViewContainer?,
+		webRequest: NativeWebRequest,
+		binderFactory: WebDataBinderFactory?,
+	) = when {
+		parameter.isScenarioSession() ->
+			webRequest.getAttribute(SessionBinderInterceptor.ATTR_SCENARIO_SESSION, RequestAttributes.SCOPE_REQUEST)
+
+		parameter.isLearnerSession() ->
+			webRequest.getAttribute(SessionBinderInterceptor.ATTR_LEARNER_SESSION, RequestAttributes.SCOPE_REQUEST)
+
+		else -> null
+	}
+
+	private fun MethodParameter.isSession() = isScenarioSession() || isLearnerSession()
+	private fun MethodParameter.isScenarioSession() = hasParameterAnnotation(ScenarioSession::class.java)
+	private fun MethodParameter.isLearnerSession() = hasParameterAnnotation(LearnerSession::class.java)
+}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/internal/SessionBinderInterceptor.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/internal/SessionBinderInterceptor.kt
@@ -1,0 +1,66 @@
+/*
+ * Elaastic / ElaastiX - formative assessment system
+ * Copyright (C) 2019  Université de Toulouse and Université Toulouse Capitole.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.elaastix.server.scenario.exec.internal
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.elaastix.commons.data.Uuid
+import org.elaastix.commons.data.UuidSerializer.tryFromBase36
+import org.elaastix.commons.exceptions.BadRequestException
+import org.elaastix.commons.platform.debt.SciconumTechDebt
+import org.elaastix.server.authn.ElaastixAuthentication
+import org.elaastix.server.scenario.exec.repositories.SciconumLearnerSessionRepository
+import org.springframework.web.servlet.HandlerInterceptor
+
+/**
+ * Interceptor binding the active scenario and learner session to the request.
+ */
+@SciconumTechDebt
+class SessionBinderInterceptor(private val learnerSessionRepository: SciconumLearnerSessionRepository) :
+	HandlerInterceptor {
+	companion object {
+		/** Request attribute name storing the scenario session entity. */
+		const val ATTR_SCENARIO_SESSION = "org.elaastix.engine.session.scenario"
+
+		/** Request attribute name storing the learner session entity. */
+		const val ATTR_LEARNER_SESSION = "org.elaastix.engine.session.learner"
+	}
+
+	override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+		val nsid = request.requestURI.split('/').last()
+
+		// Engine and platform are special purpose
+		if (nsid.startsWith("org.elaastix.engine") || nsid.startsWith("org.elaastix.platform")) return true
+
+		val sessionId = request.getParameter("sessionId")?.let { Uuid.tryFromBase36(it) }?.getOrNull()
+			?: throw BadRequestException("Missing or invalid `sessionId`")
+
+		val auth = request.userPrincipal as? ElaastixAuthentication
+			?: error("Unexpected or missing request authentication; should've been processed by Spring Security?")
+
+		val session = learnerSessionRepository.findByIdAndLearner(sessionId, auth.principal)
+			?: throw BadRequestException("Invalid session")
+
+		request.setAttribute(ATTR_LEARNER_SESSION, session)
+		request.setAttribute(ATTR_SCENARIO_SESSION, session.scenarioSession)
+
+		return true
+	}
+}

--- a/server/src/main/kotlin/org/elaastix/server/scenario/exec/repositories/SciconumLearnerSessionRepository.kt
+++ b/server/src/main/kotlin/org/elaastix/server/scenario/exec/repositories/SciconumLearnerSessionRepository.kt
@@ -19,6 +19,7 @@
 
 package org.elaastix.server.scenario.exec.repositories
 
+import org.elaastix.commons.data.Uuid
 import org.elaastix.commons.jpa.repository.ElaastixRepository
 import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.server.assignments.AssignmentEntity
@@ -34,6 +35,8 @@ import kotlin.time.Instant
 @Repository
 @SciconumTechDebt
 interface SciconumLearnerSessionRepository : ElaastixRepository<SciconumLearnerSessionEntity> {
+	fun findByIdAndLearner(id: Uuid, learner: UserEntity): SciconumLearnerSessionEntity?
+
 	@Query("FROM SciconumLearnerSessionEntity sls WHERE sls.learner = :learner AND sls.phase != 'END'")
 	fun findAllByLearnerAndNotEnded(learner: UserEntity): List<SciconumLearnerSessionEntity>
 

--- a/server/src/test/kotlin/org/elaastix/server/activity/responses/ResponseActivityServiceTest.kt
+++ b/server/src/test/kotlin/org/elaastix/server/activity/responses/ResponseActivityServiceTest.kt
@@ -28,6 +28,7 @@ import org.elaastix.commons.applyAs
 import org.elaastix.commons.cast
 import org.elaastix.commons.exceptions.BadRequestException
 import org.elaastix.commons.platform.JpaImmutable
+import org.elaastix.commons.platform.debt.SciconumTechDebt
 import org.elaastix.commons.platform.wip.UnclearAuthorshipOwnership
 import org.elaastix.mm.content.PlainText
 import org.elaastix.server.activities.response.ClosedAnswer
@@ -43,6 +44,7 @@ import org.elaastix.server.activities.response.entities.projections.QuestionStat
 import org.elaastix.server.activities.response.repositories.QuestionRepository
 import org.elaastix.server.activities.response.repositories.ResponseRepository
 import org.elaastix.server.core.AbstractEntityWithAuthorship
+import org.elaastix.server.scenario.exec.ScenarioExecutionStatusCheckService
 import org.elaastix.server.users.entities.UserEntity
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -50,11 +52,13 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import testutils.mockkEntity
 
+@OptIn(SciconumTechDebt::class)
 class ResponseActivityServiceTest {
 	val questionRepo: QuestionRepository = mockk()
 	val responseRepo: ResponseRepository = mockk()
+	val statusChecker: ScenarioExecutionStatusCheckService = mockk()
 
-	val service = ResponseActivityService(questionRepo, responseRepo)
+	val service = ResponseActivityService(questionRepo, responseRepo, statusChecker)
 
 	private inline fun <reified T : QuestionEntity> mockkStatementProjection(questionEntity: T) =
 		mockk<QuestionStatementProjection> {


### PR DESCRIPTION
Makes the current session objects available in the activity. Currently requires providing the session id as a query parameter, casts doubts on the relevance of the generic `submitResponse` (that cannot perform much checks on whether the learner is in a state that allows them to respond).

Related: #182